### PR TITLE
[MA-475] Update MoPub SDK to 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
         branchName = "${System.getenv("CIRCLE_BRANCH")}"
         buildNumber = "${System.getenv("CIRCLE_BUILD_NUM")}"
     }
-    version = "0.2.0"
+    version = "0.2.1"
     group = "net.pubnative"
 }
 

--- a/hybid.adapters.mopub/build.gradle
+++ b/hybid.adapters.mopub/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':hybid.sdk')
-    compileOnly('com.mopub:mopub-sdk:5.0.0@aar') {
+    compileOnly('com.mopub:mopub-sdk:5.2.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation('com.mopub:mopub-sdk:5.0.0@aar') {
+    implementation('com.mopub:mopub-sdk:5.2.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat


### PR DESCRIPTION
This PR contains the following changes:

- Update MoPub SDK version to 5.2.0 in Adapters and Demo
- Bump HyBid SDK version to 0.2.1