### PR TITLE
Update support libraries in demo app to 27.1.1

### DIFF
--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -38,9 +38,9 @@ dependencies {
     implementation project(':hybid.sdk')
     implementation project(':hybid.adapters.mopub')
     implementation project(':hybid.adapters.dfp')
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support:design:27.1.1'
     implementation 'com.android.support:multidex:1.0.3'
     implementation('com.mopub:mopub-sdk:5.0.0@aar') {
         transitive = true

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/adapters/KeywordAdapter.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/adapters/KeywordAdapter.kt
@@ -34,11 +34,11 @@ import net.pubnative.lite.demo.ui.viewholders.KeywordViewHolder
 class KeywordAdapter : RecyclerView.Adapter<KeywordViewHolder>() {
     private val list: MutableList<String> = mutableListOf()
 
-    override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): KeywordViewHolder
-            = KeywordViewHolder(LayoutInflater.from(parent?.context).inflate(R.layout.item_keyword, parent, false))
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): KeywordViewHolder
+            = KeywordViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.item_keyword, parent, false))
 
-    override fun onBindViewHolder(holder: KeywordViewHolder?, position: Int) {
-        holder?.bind(list[position])
+    override fun onBindViewHolder(holder: KeywordViewHolder, position: Int) {
+        holder.bind(list[position])
     }
 
     override fun getItemCount(): Int = list.size

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/adapters/ZoneIdAdapter.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/adapters/ZoneIdAdapter.kt
@@ -36,11 +36,11 @@ class ZoneIdAdapter(listener: ZoneIdClickListener?) : RecyclerView.Adapter<ZoneI
     private val list: MutableList<String> = mutableListOf()
     private var listener: ZoneIdClickListener? = listener
 
-    override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): ZoneIdViewHolder
-            = ZoneIdViewHolder(LayoutInflater.from(parent?.context).inflate(R.layout.item_zone_id, parent, false), listener)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ZoneIdViewHolder
+            = ZoneIdViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.item_zone_id, parent, false), listener)
 
-    override fun onBindViewHolder(holder: ZoneIdViewHolder?, position: Int) {
-        holder?.bind(list[position])
+    override fun onBindViewHolder(holder: ZoneIdViewHolder, position: Int) {
+        holder.bind(list[position])
     }
 
     override fun getItemCount(): Int = list.size


### PR DESCRIPTION
This PR contains the following changes:

- Update Android AppCompat and Design libraries to 27.1.1
- Update ConstraintLayout library to 1.1.2
- Fix issues with RecyclerView adapters in Kotlin after updating the libs