### PR TITLE
[MA-479] Bypass SSL security for demo app

### DIFF
--- a/hybid.demo/src/main/AndroidManifest.xml
+++ b/hybid.demo/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/hybid.demo/src/main/res/xml/network_security_config.xml
+++ b/hybid.demo/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
This PR contains the following changes:

- Bypass SSL security so Charles Proxy can be used in devices with Android 7 or higher.