### PR TITLE
Add fields on MoPub settings for mediation ad units

### DIFF
--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/config/MoPubSettingsFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/config/MoPubSettingsFragment.kt
@@ -42,6 +42,10 @@ class MoPubSettingsFragment : Fragment() {
     private lateinit var bannerInput: EditText
     private lateinit var mediumInput: EditText
     private lateinit var interstitialInput: EditText
+    private lateinit var mediationBannerInput: EditText
+    private lateinit var mediationMediumInput: EditText
+    private lateinit var mediationInterstitialInput: EditText
+    private lateinit var mediationNativeInput: EditText
     private lateinit var settingManager: SettingsManager
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
@@ -53,6 +57,10 @@ class MoPubSettingsFragment : Fragment() {
         bannerInput = view.findViewById(R.id.input_mopub_banner)
         mediumInput = view.findViewById(R.id.input_mopub_medium)
         interstitialInput = view.findViewById(R.id.input_mopub_interstitial)
+        mediationBannerInput = view.findViewById(R.id.input_mopub_mediation_banner)
+        mediationMediumInput = view.findViewById(R.id.input_mopub_mediation_medium)
+        mediationInterstitialInput = view.findViewById(R.id.input_mopub_mediation_interstitial)
+        mediationNativeInput = view.findViewById(R.id.input_mopub_mediation_native)
 
         settingManager = SettingsManager.getInstance(context!!)
 
@@ -60,15 +68,23 @@ class MoPubSettingsFragment : Fragment() {
             val bannerAdUnitId = bannerInput.text.toString()
             val mediumAdUnitId = mediumInput.text.toString()
             val interstitialAdUnitId = interstitialInput.text.toString()
+            val mediationBannerAdUnitId = mediationBannerInput.text.toString()
+            val mediationMediumAdUnitId = mediationMediumInput.text.toString()
+            val mediationInterstitialAdUnitId = mediationInterstitialInput.text.toString()
+            val mediationNativeAdUnitId = mediationNativeInput.text.toString()
 
             settingManager.setMoPubBannerAdUnitId(bannerAdUnitId)
             settingManager.setMoPubMediumAdUnitId(mediumAdUnitId)
             settingManager.setMoPubInterstitialAdUnitId(interstitialAdUnitId)
+            settingManager.setMoPubMediationBannerAdUnitId(mediationBannerAdUnitId)
+            settingManager.setMoPubMediationMediumAdUnitId(mediationMediumAdUnitId)
+            settingManager.setMoPubMediationInterstitialAdUnitId(mediationInterstitialAdUnitId)
+            settingManager.setMoPubMediationNativeAdUnitId(mediationNativeAdUnitId)
 
-            MoPubManager.initMoPubSdk(activity, bannerAdUnitId, {
+            MoPubManager.initMoPubSdk(activity, bannerAdUnitId) {
                 Toast.makeText(activity, "MoPub settings saved successfully.", Toast.LENGTH_SHORT).show()
                 activity?.finish()
-            })
+            }
         }
 
         fillSavedValues()
@@ -79,5 +95,9 @@ class MoPubSettingsFragment : Fragment() {
         bannerInput.setText(settings.mopubBannerAdUnitId)
         mediumInput.setText(settings.mopubMediumAdUnitId)
         interstitialInput.setText(settings.mopubInterstitialAdUnitId)
+        mediationBannerInput.setText(settings.mopubMediationBannerAdUnitId)
+        mediationMediumInput.setText(settings.mopubMediationMediumAdUnitId)
+        mediationInterstitialInput.setText(settings.mopubMediationInterstitialAdUnitId)
+        mediationNativeInput.setText(settings.mopubMediationNativeAdUnitId)
     }
 }

--- a/hybid.demo/src/main/res/layout/fragment_mopub_settings.xml
+++ b/hybid.demo/src/main/res/layout/fragment_mopub_settings.xml
@@ -56,6 +56,76 @@
                 android:maxLines="1" />
         </android.support.design.widget.TextInputLayout>
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/mediation"
+            android:textColor="@android:color/black"
+            android:textSize="18sp" />
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/input_mopub_mediation_banner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:hint="@string/hint_mopub_banner_ad_unit_id"
+                android:maxLines="1" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/input_mopub_mediation_medium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:hint="@string/hint_mopub_medium_ad_unit_id"
+                android:maxLines="1" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/input_mopub_mediation_interstitial"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:hint="@string/hint_mopub_interstitial_ad_unit_id"
+                android:maxLines="1" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/input_mopub_mediation_native"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:hint="@string/hint_mopub_native_ad_unit_id"
+                android:maxLines="1" />
+        </android.support.design.widget.TextInputLayout>
+
         <Button
             android:id="@+id/button_save_mopub_settings"
             android:layout_width="match_parent"

--- a/hybid.demo/src/main/res/values/strings.xml
+++ b/hybid.demo/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="hint_mopub_banner_ad_unit_id">Banner Ad Unit ID</string>
     <string name="hint_mopub_medium_ad_unit_id">Medium Ad Unit ID</string>
     <string name="hint_mopub_interstitial_ad_unit_id">Interstitial Ad Unit ID</string>
+    <string name="hint_mopub_native_ad_unit_id">Native Ad Unit ID</string>
     <string name="save_mopub_settings">Save MoPub settings</string>
 
     <string name="hint_dfp_banner_ad_unit_id">Banner Ad Unit ID</string>


### PR DESCRIPTION
This PR contains the following changes:

- Add fields to edit the MoPub Mediation ad units on the demo app