### PR TITLE
[MA-497] Support for MoPub 5.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.2.61'
 
     repositories {
         google()
@@ -8,9 +8,9 @@ buildscript {
         maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'io.fabric.tools:gradle:1.+'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         classpath 'net.saliman:gradle-cobertura-plugin:2.5.4'
@@ -24,7 +24,7 @@ subprojects {
         branchName = "${System.getenv("CIRCLE_BRANCH")}"
         buildNumber = "${System.getenv("CIRCLE_BUILD_NUM")}"
     }
-    version = "0.2.6"
+    version = "0.2.7"
     group = "net.pubnative"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 09 13:52:28 CEST 2018
+#Tue Sep 25 12:16:55 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/hybid.adapters.mopub/build.gradle
+++ b/hybid.adapters.mopub/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':hybid.sdk')
-    compileOnly('com.mopub:mopub-sdk:5.2.0@aar') {
+    compileOnly('com.mopub:mopub-sdk:5.3.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -41,10 +41,10 @@ dependencies {
     implementation project(':hybid.adapters.mopub')
     implementation project(':hybid.adapters.dfp')
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation('com.mopub:mopub-sdk:5.2.0@aar') {
+    implementation('com.mopub:mopub-sdk:5.3.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat
@@ -59,7 +59,7 @@ dependencies {
         transitive = true
     }
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/hybid.sdk/build.gradle
+++ b/hybid.sdk/build.gradle
@@ -36,8 +36,8 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:3.5.1'
-    testImplementation 'org.mockito:mockito-core:2.11.0'
+    testImplementation 'org.robolectric:robolectric:3.6.1'
+    testImplementation 'org.mockito:mockito-core:2.19.0'
     testImplementation 'com.google.truth:truth:0.36'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
     androidTestImplementation "com.android.support.test:runner:0.5", {


### PR DESCRIPTION
This PR contains the following changes:

- MoPub 5.3.0
- Kotlin 1.2.61
- Kotlin JRE 7 runtime