### PR TITLE
[MA-503] Remove extra keywords from PreBid

### DIFF
--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPBannerFragment.kt
@@ -110,12 +110,12 @@ class DFPBannerFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = PrebidUtils.getPrebidKeywordsSet(ad, zoneId)
+        val keywordSet = PrebidUtils.getPrebidKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = PrebidUtils.getPrebidKeywordsBundle(ad, zoneId)
+        val keywordBundle = PrebidUtils.getPrebidKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPInterstitialFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPInterstitialFragment.kt
@@ -99,12 +99,12 @@ class DFPInterstitialFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = PrebidUtils.getPrebidKeywordsSet(ad, zoneId)
+        val keywordSet = PrebidUtils.getPrebidKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = PrebidUtils.getPrebidKeywordsBundle(ad, zoneId)
+        val keywordBundle = PrebidUtils.getPrebidKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPMRectFragment.kt
@@ -109,12 +109,12 @@ class DFPMRectFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = PrebidUtils.getPrebidKeywordsSet(ad, zoneId)
+        val keywordSet = PrebidUtils.getPrebidKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = PrebidUtils.getPrebidKeywordsBundle(ad, zoneId)
+        val keywordBundle = PrebidUtils.getPrebidKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
@@ -100,7 +100,7 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
     // --------------- HyBid Request Listener --------------------
     override fun onRequestSuccess(ad: Ad?) {
         mopubBanner.adUnitId = adUnitId
-        mopubBanner.keywords = PrebidUtils.getPrebidKeywords(ad, zoneId)
+        mopubBanner.keywords = PrebidUtils.getPrebidKeywords(ad)
         mopubBanner.loadAd()
 
         Log.d(TAG, "onRequestSuccess")

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubInterstitialFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubInterstitialFragment.kt
@@ -99,7 +99,7 @@ class MoPubInterstitialFragment : Fragment(), RequestManager.RequestListener, Mo
 
     // --------------- HyBid Request Listener --------------------
     override fun onRequestSuccess(ad: Ad?) {
-        mopubInterstitial.keywords = PrebidUtils.getPrebidKeywords(ad, zoneId)
+        mopubInterstitial.keywords = PrebidUtils.getPrebidKeywords(ad)
         mopubInterstitial.load()
 
         Log.d(TAG, "onRequestSuccess")

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
@@ -100,7 +100,7 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
     // --------------- HyBid Request Listener --------------------
     override fun onRequestSuccess(ad: Ad?) {
         mopubMRect.adUnitId = adUnitId
-        mopubMRect.keywords = PrebidUtils.getPrebidKeywords(ad, zoneId)
+        mopubMRect.keywords = PrebidUtils.getPrebidKeywords(ad)
         mopubMRect.loadAd()
 
         Log.d(TAG, "onRequestSuccess")

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/PrebidUtils.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/PrebidUtils.java
@@ -38,36 +38,40 @@ public final class PrebidUtils {
     private static final double ECPM_POINTS_DIVIDER = 1000.0;
 
     public interface KEYS {
-        String PN = "m_pn";
-        String PN_ZONE_ID = "pn_zone_id";
         String PN_BID = "pn_bid";
+    }
+
+    public static String getPrebidKeywords(Ad ad) {
+        return getPrebidKeywords(ad, "");
     }
 
     public static String getPrebidKeywords(Ad ad, String zoneId) {
         StringBuilder stringBuilder = new StringBuilder();
 
-        stringBuilder.append(KEYS.PN).append(':').append("true").append(',');
-        stringBuilder.append(KEYS.PN_ZONE_ID).append(':').append(zoneId).append(',');
         stringBuilder.append(KEYS.PN_BID).append(':').append(getBidECPM(ad));
 
         return stringBuilder.toString();
     }
 
+    public static Bundle getPrebidKeywordsBundle(Ad ad) {
+        return getPrebidKeywordsBundle(ad, "");
+    }
+
     public static Bundle getPrebidKeywordsBundle(Ad ad, String zoneid) {
         Bundle bundle = new Bundle();
 
-        bundle.putString(KEYS.PN, "true");
-        bundle.putString(KEYS.PN_ZONE_ID, zoneid);
         bundle.putString(KEYS.PN_BID, getBidECPM(ad));
 
         return bundle;
     }
 
+    public static Set<String> getPrebidKeywordsSet(Ad ad) {
+        return getPrebidKeywordsSet(ad, "");
+    }
+
     public static Set<String> getPrebidKeywordsSet(Ad ad, String zoneid) {
         Set<String> set = new LinkedHashSet<>(3);
 
-        set.add(KEYS.PN.concat(":true"));
-        set.add(KEYS.PN_ZONE_ID.concat(":").concat(zoneid));
         set.add(KEYS.PN_BID.concat(":").concat(getBidECPM(ad)));
 
         return set;


### PR DESCRIPTION
This PR contains the following changes:

- Remove pn: true and zone_id keywords from MoPub request after probed
- Update demo app with methods without zone id.