### PR TITLE
[AN-11] Cache GAID SHA1 & MD5 on SDK initialisation 

### DIFF
--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/DeviceInfo.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/DeviceInfo.java
@@ -40,6 +40,7 @@ import android.webkit.WebView;
 
 import net.pubnative.lite.sdk.utils.Logger;
 import net.pubnative.lite.sdk.utils.PNAdvertisingIdClient;
+import net.pubnative.lite.sdk.utils.PNCrypto;
 
 import java.util.Locale;
 import java.util.TimeZone;
@@ -92,6 +93,8 @@ public class DeviceInfo {
     private static final String UNKNOWN_APP_VERSION_IDENTIFIER = "UNKNOWN";
     private final Context mContext;
     private String mAdvertisingId;
+    private String mAdvertisingIdMd5;
+    private String mAdvertisingIdSha1;
     private boolean mLimitTracking = false;
     private final ConnectivityManager mConnectivityManager;
     private Listener mListener;
@@ -117,6 +120,9 @@ public class DeviceInfo {
                     mAdvertisingId = advertisingId;
                 }
 
+                mAdvertisingIdMd5 = PNCrypto.md5(mAdvertisingId);
+                mAdvertisingIdSha1 = PNCrypto.sha1(mAdvertisingId);
+
                 if (mListener != null) {
                     mListener.onInfoLoaded();
                 }
@@ -135,6 +141,14 @@ public class DeviceInfo {
     @SuppressLint("HardwareIds")
     public String getAdvertisingId() {
         return mAdvertisingId;
+    }
+
+    public String getAdvertisingIdMd5() {
+        return mAdvertisingIdMd5;
+    }
+
+    public String getAdvertisingIdSha1() {
+        return mAdvertisingIdSha1;
     }
 
     public boolean limitTracking() {

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdRequestFactory.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdRequestFactory.java
@@ -64,8 +64,9 @@ public class AdRequestFactory {
             adRequest.dnt = "1";
         } else {
             adRequest.gid = advertisingId;
-            adRequest.gidmd5 = PNCrypto.md5(advertisingId);
-            adRequest.gidsha1 = PNCrypto.sha1(advertisingId);
+
+            adRequest.gidmd5 = mDeviceInfo.getAdvertisingIdMd5();
+            adRequest.gidsha1 = mDeviceInfo.getAdvertisingIdSha1();
         }
 
         adRequest.locale = mDeviceInfo.getLocale().getLanguage();


### PR DESCRIPTION
This PR contains the following changes:

- Cache SHA1 and MD5 at SDK init the same way that the GAID itself is being cached.
- Get both values from the cache when creating the ad request