### PR TITLE
[AN-15] Leaderboard support for Standalone integration

### DIFF
--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/api/LeaderboardRequestManager.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/api/LeaderboardRequestManager.java
@@ -1,0 +1,8 @@
+package net.pubnative.lite.sdk.api;
+
+public class LeaderboardRequestManager extends RequestManager {
+    @Override
+    protected String getAdSize() {
+        return "s";
+    }
+}

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/LeaderboardPresenter.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/LeaderboardPresenter.java
@@ -20,22 +20,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package net.pubnative.lite.sdk.models;
+package net.pubnative.lite.sdk.leaderboard.presenter;
 
-/**
- * Created by erosgarciaponte on 24.01.18.
- */
+import android.view.View;
 
-public interface ApiAssetGroupType {
-    int MRAID_BANNER_1 = 10;
-    int MRAID_BANNER_2 = 12;
-    int MRAID_MRECT = 8;
-    int MRAID_INTERSTITIAL = 21;
-    int MRAID_LEADERBOARD = 24;
+import net.pubnative.lite.sdk.models.Ad;
 
-    int VAST_MRECT = 4;
-    int VAST_INTERSTITIAL_1 = 15;
-    int VAST_INTERSTITIAL_2 = 18;
-    int VAST_INTERSTITIAL_3 = 19;
-    int VAST_INTERSTITIAL_4 = 20;
+public interface LeaderboardPresenter {
+    interface Listener {
+        void onLeaderboardLoaded(LeaderboardPresenter leaderboardPresenter, View leaderboard);
+
+        void onLeaderboardClicked(LeaderboardPresenter leaderboardPresenter);
+
+        void onLeaderboardError(LeaderboardPresenter leaderboardPresenter);
+    }
+
+    void setListener(Listener listener);
+
+    Ad getAd();
+
+    void load();
+
+    void destroy();
+
+    void startTracking();
+
+    void stopTracking();
 }

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/LeaderboardPresenterDecorator.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/LeaderboardPresenterDecorator.java
@@ -1,0 +1,120 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.sdk.leaderboard.presenter;
+
+import android.view.View;
+
+import net.pubnative.lite.sdk.models.Ad;
+import net.pubnative.lite.sdk.utils.AdTracker;
+import net.pubnative.lite.sdk.utils.CheckUtils;
+import net.pubnative.lite.sdk.utils.Logger;
+
+public class LeaderboardPresenterDecorator implements LeaderboardPresenter, LeaderboardPresenter.Listener {
+    private static final String TAG = LeaderboardPresenterDecorator.class.getSimpleName();
+    private final LeaderboardPresenter mLeaderboardPresenter;
+    private final AdTracker mAdTrackingDelegate;
+    private final LeaderboardPresenter.Listener mListener;
+    private boolean mIsDestroyed;
+
+    public LeaderboardPresenterDecorator(LeaderboardPresenter leaderboardPresenter,
+                                    AdTracker adTrackingDelegate,
+                                    LeaderboardPresenter.Listener listener) {
+        mLeaderboardPresenter = leaderboardPresenter;
+        mAdTrackingDelegate = adTrackingDelegate;
+        mListener = listener;
+    }
+
+    @Override
+    public void setListener(Listener listener) {
+        // We set the listener in the constructor instead
+    }
+
+    @Override
+    public Ad getAd() {
+        return mLeaderboardPresenter.getAd();
+    }
+
+    @Override
+    public void load() {
+        if (!CheckUtils.NoThrow.checkArgument(!mIsDestroyed, "LeaderboardPresenterDecorator is destroyed")) {
+            return;
+        }
+
+        mLeaderboardPresenter.load();
+    }
+
+    @Override
+    public void destroy() {
+        mLeaderboardPresenter.destroy();
+        mIsDestroyed = true;
+    }
+
+    @Override
+    public void startTracking() {
+        if (!CheckUtils.NoThrow.checkArgument(!mIsDestroyed, "LeaderboardPresenterDecorator is destroyed")) {
+            return;
+        }
+
+        mLeaderboardPresenter.startTracking();
+    }
+
+    @Override
+    public void stopTracking() {
+        if (!CheckUtils.NoThrow.checkArgument(!mIsDestroyed, "LeaderboardPresenterDecorator is destroyed")) {
+            return;
+        }
+
+        mLeaderboardPresenter.stopTracking();
+    }
+
+    @Override
+    public void onLeaderboardLoaded(LeaderboardPresenter leaderboardPresenter, View leaderboard) {
+        if (mIsDestroyed) {
+            return;
+        }
+
+        mAdTrackingDelegate.trackImpression();
+        mListener.onLeaderboardLoaded(leaderboardPresenter, leaderboard);
+    }
+
+    @Override
+    public void onLeaderboardClicked(LeaderboardPresenter leaderboardPresenter) {
+        if (mIsDestroyed) {
+            return;
+        }
+
+        mAdTrackingDelegate.trackClick();
+        mListener.onLeaderboardClicked(leaderboardPresenter);
+    }
+
+    @Override
+    public void onLeaderboardError(LeaderboardPresenter leaderboardPresenter) {
+        if (mIsDestroyed) {
+            return;
+        }
+
+        String errorMessage = "Leaderboard error for zone id: ";
+        Logger.d(TAG, errorMessage);
+        mListener.onLeaderboardError(leaderboardPresenter);
+    }
+}

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/LeaderboardPresenterFactory.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/LeaderboardPresenterFactory.java
@@ -1,0 +1,64 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.sdk.leaderboard.presenter;
+
+import android.content.Context;
+
+import net.pubnative.lite.sdk.models.Ad;
+import net.pubnative.lite.sdk.models.ApiAssetGroupType;
+import net.pubnative.lite.sdk.utils.AdTracker;
+import net.pubnative.lite.sdk.utils.Logger;
+
+public class LeaderboardPresenterFactory {
+    private static final String TAG = LeaderboardPresenterFactory.class.getSimpleName();
+    private final Context mContext;
+
+    public LeaderboardPresenterFactory(Context context) {
+        mContext = context;
+    }
+
+    public LeaderboardPresenter createLeaderboardPresenter(Ad ad,
+                                                           LeaderboardPresenter.Listener leaderboardPresenterListener) {
+        final LeaderboardPresenter leaderboardPresenter = fromCreativeType(ad.assetgroupid, ad);
+        if (leaderboardPresenter == null) {
+            return null;
+        }
+
+        final LeaderboardPresenterDecorator leaderboardPresenterDecorator = new LeaderboardPresenterDecorator(leaderboardPresenter,
+                new AdTracker(ad.getBeacons(Ad.Beacon.IMPRESSION), ad.getBeacons(Ad.Beacon.CLICK)), leaderboardPresenterListener);
+        leaderboardPresenter.setListener(leaderboardPresenterDecorator);
+        return leaderboardPresenterDecorator;
+    }
+
+    LeaderboardPresenter fromCreativeType(int assetGroupId, Ad ad) {
+        switch (assetGroupId) {
+            case ApiAssetGroupType.MRAID_LEADERBOARD: {
+                return new MraidLeaderboardPresenter(mContext, ad);
+            }
+            default: {
+                Logger.e(TAG, "Incompatible asset group type: " + assetGroupId + ", for leaderboard ad format.");
+                return null;
+            }
+        }
+    }
+}

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/MraidLeaderboardPresenter.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/leaderboard/presenter/MraidLeaderboardPresenter.java
@@ -1,0 +1,173 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.sdk.leaderboard.presenter;
+
+import android.content.Context;
+
+import net.pubnative.lite.sdk.models.APIAsset;
+import net.pubnative.lite.sdk.models.Ad;
+import net.pubnative.lite.sdk.mraid.MRAIDBanner;
+import net.pubnative.lite.sdk.mraid.MRAIDNativeFeature;
+import net.pubnative.lite.sdk.mraid.MRAIDNativeFeatureListener;
+import net.pubnative.lite.sdk.mraid.MRAIDView;
+import net.pubnative.lite.sdk.mraid.MRAIDViewListener;
+import net.pubnative.lite.sdk.utils.CheckUtils;
+import net.pubnative.lite.sdk.utils.UrlHandler;
+
+public class MraidLeaderboardPresenter implements LeaderboardPresenter, MRAIDViewListener, MRAIDNativeFeatureListener {
+    private final Context mContext;
+    private final Ad mAd;
+    private final UrlHandler mUrlHandlerDelegate;
+    private final String[] mSupportedNativeFeatures;
+
+    private LeaderboardPresenter.Listener mListener;
+    private MRAIDBanner mMRAIDBanner;
+    private boolean mIsDestroyed;
+
+    public MraidLeaderboardPresenter(Context context, Ad ad) {
+        mContext = context;
+        mAd = ad;
+        mUrlHandlerDelegate = new UrlHandler(context);
+        mSupportedNativeFeatures = new String[]{
+                MRAIDNativeFeature.CALENDAR,
+                MRAIDNativeFeature.INLINE_VIDEO,
+                MRAIDNativeFeature.SMS,
+                MRAIDNativeFeature.STORE_PICTURE,
+                MRAIDNativeFeature.TEL
+        };
+    }
+
+    @Override
+    public void setListener(Listener listener) {
+        mListener = listener;
+    }
+
+    @Override
+    public Ad getAd() {
+        return mAd;
+    }
+
+    @Override
+    public void load() {
+        if (!CheckUtils.NoThrow.checkArgument(!mIsDestroyed, "MraidLeaderboardPresenter is destroyed")) {
+            return;
+        }
+
+        if (mAd.getAssetUrl(APIAsset.HTML_BANNER) != null) {
+            mMRAIDBanner = new MRAIDBanner(mContext, mAd.getAssetUrl(APIAsset.HTML_BANNER), "", mSupportedNativeFeatures,
+                    this, this, mAd.getContentInfoContainer(mContext));
+        } else if (mAd.getAssetHtml(APIAsset.HTML_BANNER) != null) {
+            mMRAIDBanner = new MRAIDBanner(mContext, "", mAd.getAssetHtml(APIAsset.HTML_BANNER), mSupportedNativeFeatures,
+                    this, this, mAd.getContentInfoContainer(mContext));
+        }
+
+    }
+
+    @Override
+    public void destroy() {
+        if (mMRAIDBanner != null) {
+            mMRAIDBanner.destroy();
+        }
+        mListener = null;
+        mIsDestroyed = true;
+    }
+
+    @Override
+    public void startTracking() {
+
+    }
+
+    @Override
+    public void stopTracking() {
+
+    }
+
+    @Override
+    public void mraidViewLoaded(MRAIDView mraidView) {
+        if (mIsDestroyed) {
+            return;
+        }
+
+        if (mListener != null) {
+            mListener.onLeaderboardLoaded(this, mraidView);
+        }
+    }
+
+    @Override
+    public void mraidViewExpand(MRAIDView mraidView) {
+        if (mIsDestroyed) {
+            return;
+        }
+
+        if (mListener != null) {
+            mListener.onLeaderboardClicked(this);
+        }
+    }
+
+    @Override
+    public void mraidViewClose(MRAIDView mraidView) {
+
+    }
+
+    @Override
+    public boolean mraidViewResize(MRAIDView mraidView, int width, int height, int offsetX, int offsetY) {
+        return true;
+    }
+
+    @Override
+    public void mraidNativeFeatureCallTel(String url) {
+
+    }
+
+    @Override
+    public void mraidNativeFeatureCreateCalendarEvent(String eventJSON) {
+
+    }
+
+    @Override
+    public void mraidNativeFeaturePlayVideo(String url) {
+
+    }
+
+    @Override
+    public void mraidNativeFeatureOpenBrowser(String url) {
+        if (mIsDestroyed) {
+            return;
+        }
+
+        mUrlHandlerDelegate.handleUrl(url);
+        if (mListener != null) {
+            mListener.onLeaderboardClicked(this);
+        }
+    }
+
+    @Override
+    public void mraidNativeFeatureStorePicture(String url) {
+
+    }
+
+    @Override
+    public void mraidNativeFeatureSendSms(String url) {
+
+    }
+}

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/views/HyBidLeaderboardAdView.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/views/HyBidLeaderboardAdView.java
@@ -1,0 +1,118 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.sdk.views;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import net.pubnative.lite.sdk.api.LeaderboardRequestManager;
+import net.pubnative.lite.sdk.api.RequestManager;
+import net.pubnative.lite.sdk.leaderboard.presenter.LeaderboardPresenter;
+import net.pubnative.lite.sdk.leaderboard.presenter.LeaderboardPresenterFactory;
+
+public class HyBidLeaderboardAdView extends PNAdView implements LeaderboardPresenter.Listener {
+    private LeaderboardPresenter mPresenter;
+
+    public HyBidLeaderboardAdView(Context context) {
+        super(context);
+    }
+
+    public HyBidLeaderboardAdView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public HyBidLeaderboardAdView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @TargetApi(21)
+    public HyBidLeaderboardAdView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    @Override
+    protected void cleanup() {
+        super.cleanup();
+        if (mPresenter != null) {
+            mPresenter.destroy();
+            mPresenter = null;
+        }
+    }
+
+    @Override
+    protected String getLogTag() {
+        return HyBidLeaderboardAdView.class.getSimpleName();
+    }
+
+    @Override
+    RequestManager getRequestManager() {
+        return new LeaderboardRequestManager();
+    }
+
+    @Override
+    protected void renderAd() {
+        mPresenter = new LeaderboardPresenterFactory(getContext())
+                .createLeaderboardPresenter(mAd, this);
+        if (mPresenter != null) {
+            mPresenter.load();
+        } else {
+            invokeOnLoadFailed(new Exception("The server has returned an unsupported ad asset"));
+        }
+    }
+
+    @Override
+    protected void startTracking() {
+        if (mPresenter != null) {
+            mPresenter.startTracking();
+        }
+    }
+
+    @Override
+    protected void stopTracking() {
+        if (mPresenter != null) {
+            mPresenter.stopTracking();
+        }
+    }
+
+    //----------------------------- LeaderboardPresenter Callbacks --------------------------------------
+    @Override
+    public void onLeaderboardLoaded(LeaderboardPresenter leaderboardPresenter, View leaderboard) {
+        if (leaderboard == null) {
+            invokeOnLoadFailed(new Exception("An error has occurred while rendering the ad"));
+        } else {
+            setupAdView(leaderboard);
+        }
+    }
+
+    @Override
+    public void onLeaderboardError(LeaderboardPresenter leaderboardPresenter) {
+        invokeOnLoadFailed(new Exception("An error has occurred while rendering the ad"));
+    }
+
+    @Override
+    public void onLeaderboardClicked(LeaderboardPresenter leaderboardPresenter) {
+        invokeOnClick();
+    }
+}

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/views/PNLeaderboardAdView.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/views/PNLeaderboardAdView.java
@@ -1,0 +1,50 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.sdk.views;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class PNLeaderboardAdView extends HyBidLeaderboardAdView {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+
+    public PNLeaderboardAdView(Context context) {
+        super(context);
+    }
+
+    public PNLeaderboardAdView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public PNLeaderboardAdView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @TargetApi(21)
+    public PNLeaderboardAdView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+}


### PR DESCRIPTION
This PR contains the following changes:

- Support for Leaderboard size banners (728x90)
- HyBidLeaderboardAdView as a self contained view for the leaderboard ads