### PR TITLE
[AN-31] Fix ad cache for Prebid interstitial

### DIFF
--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubInterstitialCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubInterstitialCustomEvent.java
@@ -73,7 +73,7 @@ public class HyBidMoPubInterstitialCustomEvent extends CustomEventInterstitial i
             return;
         }
 
-        final Ad ad = HyBid.getAdCache().remove(zoneIdKey);
+        final Ad ad = HyBid.getAdCache().inspect(zoneIdKey);
         if (ad == null) {
             Logger.e(TAG, "Could not find an ad in the cache for zone id with key " + zoneIdKey);
             mInterstitialListener.onInterstitialFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/AdCache.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/AdCache.java
@@ -44,6 +44,10 @@ public class AdCache {
         return mAdMap.remove(zoneId);
     }
 
+    public Ad inspect(String zoneId) {
+        return mAdMap.get(zoneId);
+    }
+
     public void put(String zoneId, Ad ad) {
         Logger.d(TAG, "AdCache putting ad for zone id: " + zoneId);
         mAdMap.put(zoneId, ad);


### PR DESCRIPTION
This PR contains the following changes:

- Add method **inspect** in the AdCache to check ads without removing.
- Replace **remove** method from AdCache by **inspect** in prebid interstitial adapter