### PR TITLE
[AN-48] Update MoPub SDK 5.5.0

### DIFF
--- a/hybid.adapters.mopub/build.gradle
+++ b/hybid.adapters.mopub/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':hybid.sdk')
-    compileOnly('com.mopub:mopub-sdk:5.4.0@aar') {
+    compileOnly('com.mopub:mopub-sdk:5.5.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.1.0-alpha03'
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation('com.mopub:mopub-sdk:5.4.0@aar') {
+    implementation('com.mopub:mopub-sdk:5.5.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/managers/MoPubManager.java
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/managers/MoPubManager.java
@@ -27,6 +27,7 @@ import android.content.Context;
 import com.mopub.common.MoPub;
 import com.mopub.common.SdkConfiguration;
 import com.mopub.common.SdkInitializationListener;
+import com.mopub.common.logging.MoPubLog;
 
 public class MoPubManager {
     public static void initMoPubSdk(Context context, String adUnitId) {
@@ -36,6 +37,7 @@ public class MoPubManager {
     public static void initMoPubSdk(Context context, String adUnitId, final InitialisationListener listener) {
         SdkConfiguration sdkConfiguration = new SdkConfiguration
                 .Builder(adUnitId)
+                .withLogLevel(MoPubLog.LogLevel.DEBUG)
                 .build();
         MoPub.initializeSdk(context, sdkConfiguration, new SdkInitializationListener() {
             @Override


### PR DESCRIPTION
This PR contains the following changes:

- Update MoPub SDK support to 5.5.0
- Set MoPub log levels to DEBUG, therefore seeing all actions triggered but the SDK.