### PR TITLE
Fix duplicated ad choices insertion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         branchName = "${System.getenv("CIRCLE_BRANCH")}"
         buildNumber = "${System.getenv("CIRCLE_BUILD_NUM")}"
     }
-    version = "0.4.7"
+    version = "0.4.8"
     group = "net.pubnative"
 }
 

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/mraid/MRAIDView.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/mraid/MRAIDView.java
@@ -48,6 +48,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.ClientCertRequest;
@@ -179,6 +180,8 @@ public class MRAIDView extends RelativeLayout {
     private final GestureDetector gestureDetector;
 
     private boolean wasTouched = false;
+
+    private boolean contentInfoAdded = false;
 
     // true if this is an interstitial ad (TODO: move behavior to MRAIDInterstitial)
     private final boolean isInterstitial;
@@ -474,6 +477,7 @@ public class MRAIDView extends RelativeLayout {
         }
 
         currentWebView = null;
+        contentInfoAdded = false;
     }
 
     /**************************************************************************
@@ -1099,8 +1103,9 @@ public class MRAIDView extends RelativeLayout {
     }
 
     private void addContentInfo(View view) {
-        if (contentInfo != null) {
+        if (contentInfo != null && !contentInfoAdded) {
             ((ViewGroup) view).addView(contentInfo);
+            contentInfoAdded = true;
         }
     }
 


### PR DESCRIPTION
This PR contains the following changes:

- Add flag to prevent ad choices to be added twice in case that the HTML view does an internal load of a different page.