### PR TITLE
Update Gradle for new Android Studio 3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.30'
 
     repositories {
         google()
@@ -8,8 +8,8 @@ buildscript {
         maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath 'io.fabric.tools:gradle:1.27.1'
+        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'io.fabric.tools:gradle:1.28.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 15 09:53:08 CET 2019
+#Thu Apr 18 10:37:07 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/hybid.sdk/build.gradle
+++ b/hybid.sdk/build.gradle
@@ -37,7 +37,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.8'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     testImplementation 'com.google.truth:truth:0.36'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
     androidTestImplementation "androidx.test:runner:1.1.0-beta01", {


### PR DESCRIPTION
This PR contains the following changes:

- Update Gradle plugin to 3.4.0
- Update Kotlin to 1.3.30