### PR TITLE
[AN-78] Check Lint on CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,20 @@ jobs:
           path: app/build/test-results/
           destination: /test-results/
 
+  lint_check:
+    <<: *android_config
+    steps:
+      - checkout
+      - *restore_gradle_cache
+      - *restore_gems_cache
+      - *ruby_yum
+      - *ruby_dependencies
+      - *save_gradle_cache
+      - *save_gems_cache
+      - run:
+          name: Run Lint checks
+          command: bundle exec fastlane lint_check
+
   send_coverage_report:
     <<: *android_config
     steps:
@@ -124,6 +138,10 @@ workflows:
       - test_unit
 
       - send_coverage_report:
+          requires:
+            - test_unit
+
+      - lint_check:
           requires:
             - test_unit
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,11 @@ platform :android do
         gradle(task: "test")
     end
 
+    desc "Runs Lint on the code"
+        lane :lint_check do
+            gradle(task: "lint")
+        end
+
     desc "Submit a new Beta Build to Crashlytics Beta"
     lane :deploy_to_crashlytics do
         gradle(task: "clean assembleDebug")


### PR DESCRIPTION
This PR contains the following changes:

- Add lane for lint checks on the CircleCI build
- Make build fail if code conventions are not respected