### PR TITLE
[OMA-536] Impression ID on standalone ad view

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'io.fabric.tools:gradle:1.28.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidBannerFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.hybid
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -48,6 +49,7 @@ class HyBidBannerFragment : Fragment(), PNAdView.Listener {
     private lateinit var hybidBanner: HyBidBannerAdView
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_hybid_banner, container, false)
@@ -56,6 +58,7 @@ class HyBidBannerFragment : Fragment(), PNAdView.Listener {
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        impressionIdView = view.findViewById(R.id.view_impression_id)
         loadButton = view.findViewById(R.id.button_load)
         hybidBanner = view.findViewById(R.id.hybid_banner)
 
@@ -69,6 +72,7 @@ class HyBidBannerFragment : Fragment(), PNAdView.Listener {
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -84,6 +88,9 @@ class HyBidBannerFragment : Fragment(), PNAdView.Listener {
     override fun onAdLoaded() {
         Log.d(TAG, "onAdLoaded")
         displayLogs()
+        if (!TextUtils.isEmpty(hybidBanner.impressionId)) {
+            impressionIdView.text = hybidBanner.impressionId
+        }
     }
 
     override fun onAdLoadFailed(error: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidInterstitialFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidInterstitialFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.hybid
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -46,6 +47,7 @@ class HyBidInterstitialFragment : Fragment(), HyBidInterstitialAd.Listener {
 
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
     private var interstitial: HyBidInterstitialAd? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_hybid_interstitial, container, false)
@@ -54,6 +56,7 @@ class HyBidInterstitialFragment : Fragment(), HyBidInterstitialAd.Listener {
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        impressionIdView = view.findViewById(R.id.view_impression_id)
         loadButton = view.findViewById(R.id.button_load)
 
 
@@ -67,6 +70,7 @@ class HyBidInterstitialFragment : Fragment(), HyBidInterstitialAd.Listener {
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -83,6 +87,9 @@ class HyBidInterstitialFragment : Fragment(), HyBidInterstitialAd.Listener {
         Log.d(TAG, "onInterstitialLoaded")
         interstitial?.show()
         displayLogs()
+        if (!TextUtils.isEmpty(interstitial?.impressionId)) {
+            impressionIdView.text = interstitial?.impressionId
+        }
     }
 
     override fun onInterstitialLoadFailed(error: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidLeaderboardFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidLeaderboardFragment.kt
@@ -1,6 +1,7 @@
 package net.pubnative.lite.demo.ui.fragments.hybid
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -23,6 +24,7 @@ class HyBidLeaderboardFragment : Fragment(), PNAdView.Listener {
     private lateinit var hybidLeaderboard: HyBidLeaderboardAdView
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_hybid_leaderboard, container, false)
@@ -31,6 +33,7 @@ class HyBidLeaderboardFragment : Fragment(), PNAdView.Listener {
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        impressionIdView = view.findViewById(R.id.view_impression_id)
         loadButton = view.findViewById(R.id.button_load)
         hybidLeaderboard = view.findViewById(R.id.hybid_leaderboard)
 
@@ -44,6 +47,7 @@ class HyBidLeaderboardFragment : Fragment(), PNAdView.Listener {
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -59,6 +63,9 @@ class HyBidLeaderboardFragment : Fragment(), PNAdView.Listener {
     override fun onAdLoaded() {
         Log.d(TAG, "onAdLoaded")
         displayLogs()
+        if (!TextUtils.isEmpty(hybidLeaderboard.impressionId)) {
+            impressionIdView.text = hybidLeaderboard.impressionId
+        }
     }
 
     override fun onAdLoadFailed(error: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidMRectFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.hybid
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -49,6 +50,7 @@ class HyBidMRectFragment : Fragment(), InFeedAdListener {
 
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
     private lateinit var recyclerView: RecyclerView
 
     private lateinit var adapter: InFeedAdapter
@@ -59,6 +61,7 @@ class HyBidMRectFragment : Fragment(), InFeedAdListener {
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        impressionIdView = view.findViewById(R.id.view_impression_id)
         loadButton = view.findViewById(R.id.button_load)
         recyclerView = view.findViewById(R.id.list)
 
@@ -78,6 +81,7 @@ class HyBidMRectFragment : Fragment(), InFeedAdListener {
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -97,6 +101,12 @@ class HyBidMRectFragment : Fragment(), InFeedAdListener {
     override fun onInFeedAdLoadError(error: Throwable?) {
         errorView.text = error?.message
         displayLogs()
+    }
+
+    override fun onInFeedAdImpressionId(impressionId: String?) {
+        if (!TextUtils.isEmpty(impressionId)) {
+            impressionIdView.text = impressionId
+        }
     }
 
     private fun displayLogs() {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidNativeFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/hybid/HyBidNativeFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.hybid
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -53,6 +54,7 @@ class HyBidNativeFragment : Fragment(), HyBidNativeAdRequest.RequestListener, Na
 
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
     private var nativeAd: NativeAd? = null
     private var nativeAdRequest: HyBidNativeAdRequest? = null
@@ -63,6 +65,7 @@ class HyBidNativeFragment : Fragment(), HyBidNativeAdRequest.RequestListener, Na
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        impressionIdView = view.findViewById(R.id.view_impression_id)
 
         loadButton = view.findViewById(R.id.button_load)
 
@@ -87,6 +90,7 @@ class HyBidNativeFragment : Fragment(), HyBidNativeAdRequest.RequestListener, Na
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -117,6 +121,9 @@ class HyBidNativeFragment : Fragment(), HyBidNativeAdRequest.RequestListener, Na
     override fun onRequestSuccess(ad: NativeAd?) {
         renderAd(ad)
         displayLogs()
+        if (!TextUtils.isEmpty(ad?.impressionId)) {
+            impressionIdView.text = ad?.impressionId
+        }
     }
 
     override fun onRequestFail(throwable: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.mopub
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -55,6 +56,7 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
     private lateinit var mopubBanner: MoPubView
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_mopub_banner, container, false)
 
@@ -62,6 +64,9 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        view.findViewById<TextView>(R.id.label_impression_id).visibility = View.VISIBLE
+        impressionIdView = view.findViewById(R.id.view_impression_id)
+        impressionIdView.visibility = View.VISIBLE
         loadButton = view.findViewById(R.id.button_load)
         mopubBanner = view.findViewById(R.id.mopub_banner)
         mopubBanner.bannerAdListener = this
@@ -80,6 +85,7 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -101,6 +107,9 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
 
         Log.d(TAG, "onRequestSuccess")
         displayLogs()
+        if (!TextUtils.isEmpty(ad?.impressionId)) {
+            impressionIdView.text = ad?.impressionId
+        }
     }
 
     override fun onRequestFail(throwable: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubInterstitialFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubInterstitialFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.mopub
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -55,6 +56,7 @@ class MoPubInterstitialFragment : Fragment(), RequestManager.RequestListener, Mo
 
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_mopub_interstitial, container, false)
 
@@ -62,6 +64,9 @@ class MoPubInterstitialFragment : Fragment(), RequestManager.RequestListener, Mo
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        view.findViewById<TextView>(R.id.label_impression_id).visibility = View.VISIBLE
+        impressionIdView = view.findViewById(R.id.view_impression_id)
+        impressionIdView.visibility = View.VISIBLE
         loadButton = view.findViewById(R.id.button_load)
 
         adUnitId = SettingsManager.getInstance(activity!!).getSettings().mopubInterstitialAdUnitId
@@ -80,6 +85,7 @@ class MoPubInterstitialFragment : Fragment(), RequestManager.RequestListener, Mo
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -100,6 +106,9 @@ class MoPubInterstitialFragment : Fragment(), RequestManager.RequestListener, Mo
 
         Log.d(TAG, "onRequestSuccess")
         displayLogs()
+        if (!TextUtils.isEmpty(ad?.impressionId)) {
+            impressionIdView.text = ad?.impressionId
+        }
     }
 
     override fun onRequestFail(throwable: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubLeaderboardFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubLeaderboardFragment.kt
@@ -1,6 +1,7 @@
 package net.pubnative.lite.demo.ui.fragments.mopub
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -30,6 +31,7 @@ class MoPubLeaderboardFragment : Fragment(), RequestManager.RequestListener, MoP
     private lateinit var mopubLeaderboard: MoPubView
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_mopub_leaderboard, container, false)
 
@@ -37,6 +39,9 @@ class MoPubLeaderboardFragment : Fragment(), RequestManager.RequestListener, MoP
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        view.findViewById<TextView>(R.id.label_impression_id).visibility = View.VISIBLE
+        impressionIdView = view.findViewById(R.id.view_impression_id)
+        impressionIdView.visibility = View.VISIBLE
         loadButton = view.findViewById(R.id.button_load)
         mopubLeaderboard = view.findViewById(R.id.mopub_leaderboard)
         mopubLeaderboard.bannerAdListener = this
@@ -55,6 +60,7 @@ class MoPubLeaderboardFragment : Fragment(), RequestManager.RequestListener, MoP
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -76,6 +82,9 @@ class MoPubLeaderboardFragment : Fragment(), RequestManager.RequestListener, MoP
 
         Log.d(TAG, "onRequestSuccess")
         displayLogs()
+        if (!TextUtils.isEmpty(ad?.impressionId)) {
+            impressionIdView.text = ad?.impressionId
+        }
     }
 
     override fun onRequestFail(throwable: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
@@ -23,6 +23,7 @@
 package net.pubnative.lite.demo.ui.fragments.mopub
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -55,6 +56,7 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
     private lateinit var mopubMRect: MoPubView
     private lateinit var loadButton: Button
     private lateinit var errorView: TextView
+    private lateinit var impressionIdView: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = inflater.inflate(R.layout.fragment_mopub_mrect, container, false)
 
@@ -62,6 +64,9 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
         super.onViewCreated(view, savedInstanceState)
 
         errorView = view.findViewById(R.id.view_error)
+        view.findViewById<TextView>(R.id.label_impression_id).visibility = View.VISIBLE
+        impressionIdView = view.findViewById(R.id.view_impression_id)
+        impressionIdView.visibility = View.VISIBLE
         loadButton = view.findViewById(R.id.button_load)
         mopubMRect = view.findViewById(R.id.mopub_mrect)
         mopubMRect.bannerAdListener = this
@@ -80,6 +85,7 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
         }
 
         errorView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, errorView.text.toString()) }
+        impressionIdView.setOnClickListener { ClipboardUtils.copyToClipboard(activity!!, impressionIdView.text.toString()) }
     }
 
     override fun onDestroy() {
@@ -101,6 +107,9 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
 
         Log.d(TAG, "onRequestSuccess")
         displayLogs()
+        if (!TextUtils.isEmpty(ad?.impressionId)) {
+            impressionIdView.text = ad?.impressionId
+        }
     }
 
     override fun onRequestFail(throwable: Throwable?) {

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/listeners/InFeedAdListener.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/listeners/InFeedAdListener.kt
@@ -4,4 +4,6 @@ interface InFeedAdListener {
     fun onInFeedAdLoaded()
 
     fun onInFeedAdLoadError(error: Throwable?)
+
+    fun onInFeedAdImpressionId(impressionId: String?)
 }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/viewholders/HyBidMRectViewHolder.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/viewholders/HyBidMRectViewHolder.kt
@@ -14,7 +14,7 @@ class HyBidMRectViewHolder(itemView: View, val adListener: InFeedAdListener) : R
 
     private val adView: HyBidMRectAdView = itemView.findViewById(R.id.mrect_view)
 
-    fun bind(zoneId: String, shouldLoad : Boolean) {
+    fun bind(zoneId: String, shouldLoad: Boolean) {
         if (!TextUtils.isEmpty(zoneId) && shouldLoad) {
             adView.visibility = View.VISIBLE
             adView.load(zoneId, this)
@@ -25,6 +25,7 @@ class HyBidMRectViewHolder(itemView: View, val adListener: InFeedAdListener) : R
         Log.d(TAG, "onAdLoaded")
 
         adListener.onInFeedAdLoaded()
+        adListener.onInFeedAdImpressionId(adView.impressionId)
     }
 
     override fun onAdLoadFailed(error: Throwable?) {

--- a/hybid.demo/src/main/res/layout/fragment_hybid_banner.xml
+++ b/hybid.demo/src/main/res/layout/fragment_hybid_banner.xml
@@ -29,6 +29,35 @@
             android:layout_gravity="center_horizontal" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_hybid_interstitial.xml
+++ b/hybid.demo/src/main/res/layout/fragment_hybid_interstitial.xml
@@ -22,6 +22,35 @@
             android:textColor="@android:color/white" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_hybid_leaderboard.xml
+++ b/hybid.demo/src/main/res/layout/fragment_hybid_leaderboard.xml
@@ -29,6 +29,35 @@
             android:layout_gravity="center_horizontal" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_hybid_mrect.xml
+++ b/hybid.demo/src/main/res/layout/fragment_hybid_mrect.xml
@@ -19,11 +19,40 @@
         android:textColor="@android:color/white" />
 
     <TextView
-        android:id="@+id/label_error"
+        android:id="@+id/label_impression_id"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:fontFamily="@font/roboto"
+        android:text="@string/impression_id"
+        android:textColor="?colorPrimaryVariant"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/view_impression_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:clickable="true"
+        android:ellipsize="end"
+        android:focusable="true"
+        android:fontFamily="@font/roboto"
+        android:gravity="center"
+        android:maxLines="1"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/label_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
         android:fontFamily="@font/roboto"
         android:text="@string/error"
@@ -48,5 +77,5 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/hybid.demo/src/main/res/layout/fragment_hybid_native.xml
+++ b/hybid.demo/src/main/res/layout/fragment_hybid_native.xml
@@ -112,6 +112,35 @@
         </RelativeLayout>
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_mopub_banner.xml
+++ b/hybid.demo/src/main/res/layout/fragment_mopub_banner.xml
@@ -29,6 +29,37 @@
             android:layout_gravity="center_horizontal" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_mopub_interstitial.xml
+++ b/hybid.demo/src/main/res/layout/fragment_mopub_interstitial.xml
@@ -22,6 +22,37 @@
             android:textColor="@android:color/white" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_mopub_leaderboard.xml
+++ b/hybid.demo/src/main/res/layout/fragment_mopub_leaderboard.xml
@@ -29,6 +29,37 @@
             android:layout_gravity="center_horizontal" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/layout/fragment_mopub_mrect.xml
+++ b/hybid.demo/src/main/res/layout/fragment_mopub_mrect.xml
@@ -29,6 +29,37 @@
             android:layout_gravity="center_horizontal" />
 
         <TextView
+            android:id="@+id/label_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/roboto"
+            android:text="@string/impression_id"
+            android:textColor="?colorPrimaryVariant"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/view_impression_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:ellipsize="end"
+            android:focusable="true"
+            android:fontFamily="@font/roboto"
+            android:gravity="center"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/label_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/hybid.demo/src/main/res/values/strings.xml
+++ b/hybid.demo/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
 
     <string name="mediation">Mediation</string>
 
+    <string name="impression_id">Impression ID:</string>
     <string name="error">Error:</string>
     <string name="request_url">PubNative request url:</string>
     <string name="response">PubNative response:</string>

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/interstitial/HyBidInterstitialAd.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/interstitial/HyBidInterstitialAd.java
@@ -52,6 +52,7 @@ public class HyBidInterstitialAd implements RequestManager.RequestListener, Inte
     private final Listener mListener;
     private final Activity mActivity;
     private final String mZoneId;
+    private Ad mAd;
     private boolean mReady = false;
 
     public HyBidInterstitialAd(Activity activity, String zoneId, Listener listener) {
@@ -100,8 +101,12 @@ public class HyBidInterstitialAd implements RequestManager.RequestListener, Inte
         }
     }
 
-    private void renderAd(Ad ad) {
-        mPresenter = new InterstitialPresenterFactory(mActivity, mZoneId).createInterstitialPresenter(ad, this);
+    public String getImpressionId() {
+        return mAd != null ? mAd.getImpressionId() : null;
+    }
+
+    private void renderAd() {
+        mPresenter = new InterstitialPresenterFactory(mActivity, mZoneId).createInterstitialPresenter(mAd, this);
         if (mPresenter != null) {
             mPresenter.load();
         } else {
@@ -146,7 +151,8 @@ public class HyBidInterstitialAd implements RequestManager.RequestListener, Inte
         if (ad == null) {
             invokeOnLoadFailed(new Exception("Server returned null ad"));
         } else {
-            renderAd(ad);
+            mAd = ad;
+            renderAd();
         }
     }
 

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/NativeAd.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/NativeAd.java
@@ -181,6 +181,10 @@ public class NativeAd implements ImpressionTracker.Listener {
         return mAd.getContentInfo(context);
     }
 
+    public String getImpressionId() {
+        return mAd != null ? mAd.getImpressionId() : null;
+    }
+
     // Used to inject extra data in urls
     private String injectExtras(String url) {
         String result = url;

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/views/PNAdView.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/views/PNAdView.java
@@ -108,6 +108,10 @@ public abstract class PNAdView extends RelativeLayout implements RequestManager.
         }
     }
 
+    public String getImpressionId() {
+        return mAd != null ? mAd.getImpressionId() : null;
+    }
+
     protected abstract String getLogTag();
 
     abstract RequestManager getRequestManager();


### PR DESCRIPTION
This PR contains the following changes:

- Add function to get Impression ID from standalone ads
- Add field on standalone and header bidding screens on the demo app to display the impression ID