### PR TITLE
[OMA-646] MoPub SDK 5.11.0 support

### DIFF
--- a/hybid.adapters.admob/build.gradle
+++ b/hybid.adapters.admob/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode System.getenv("CIRCLE_BUILD_NUM") ? System.getenv("CIRCLE_BUILD_NUM").toInteger() : 1
         versionName version_name

--- a/hybid.adapters.dfp/build.gradle
+++ b/hybid.adapters.dfp/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode System.getenv("CIRCLE_BUILD_NUM") ? System.getenv("CIRCLE_BUILD_NUM").toInteger() : 1
         versionName version_name

--- a/hybid.adapters.mopub/build.gradle
+++ b/hybid.adapters.mopub/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode System.getenv("CIRCLE_BUILD_NUM") ? System.getenv("CIRCLE_BUILD_NUM").toInteger() : 1
         versionName version_name
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':hybid.sdk')
-    compileOnly('com.mopub:mopub-sdk:5.10.0@aar') {
+    compileOnly('com.mopub:mopub-sdk:5.11.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "net.pubnative.lite.demo"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode System.getenv("CIRCLE_BUILD_NUM") ? System.getenv("CIRCLE_BUILD_NUM").toInteger() : 1
         versionName project.version
@@ -52,10 +52,10 @@ dependencies {
     implementation project(':hybid.adapters.dfp')
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
-    implementation 'com.google.android.material:material:1.2.0-alpha03'
+    implementation 'com.google.android.material:material:1.2.0-alpha04'
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation('com.mopub:mopub-sdk:5.10.0@aar') {
+    implementation('com.mopub:mopub-sdk:5.11.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat
@@ -66,7 +66,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
 }

--- a/hybid.sdk/build.gradle
+++ b/hybid.sdk/build.gradle
@@ -18,7 +18,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode System.getenv("CIRCLE_BUILD_NUM") ? System.getenv("CIRCLE_BUILD_NUM").toInteger() : 1
         versionName version_name


### PR DESCRIPTION
This PR contains the following changes:

- Raise minimum api version required for HyBid SDK to 19
- Update MoPub SDK to 5.11.0