### PR TITLE
Add redirect=false as param in the click url

### DIFF
--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/UrlHandler.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/UrlHandler.java
@@ -55,6 +55,8 @@ public class UrlHandler {
         final String host = uri.getHost();
         final String uriLower = uri.toString().toLowerCase(Locale.ROOT);
 
+        final Uri processedUri = uri.buildUpon().appendQueryParameter("redirect", "false").build();
+
         // NOTE: currently these all handle the same, but we might want different behavior in the future
 
         // Play store deep links
@@ -63,17 +65,17 @@ public class UrlHandler {
                 || "market".equalsIgnoreCase(scheme)
                 || uriLower.startsWith("play.google.com")
                 || uriLower.startsWith("market.android.com/")) {
-            mIntentHandler.handleDeepLink(uri);
+            mIntentHandler.handleDeepLink(processedUri);
         }
 
         // Device browser
         else if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
-            mIntentHandler.handleDeepLink(uri);
+            mIntentHandler.handleDeepLink(processedUri);
         }
 
         // App deep links
         else if (!scheme.isEmpty()) {
-            mIntentHandler.handleDeepLink(uri);
+            mIntentHandler.handleDeepLink(processedUri);
         }
     }
 }


### PR DESCRIPTION
This PR contains the following changes:

- Add redirect=false as a param in the click url of creatives. It's an anti fraud measure.