### PR TITLE
Update MoPub, Admob and bump HyBid version to 0.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.70'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         google()
@@ -7,14 +7,14 @@ buildscript {
         maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         classpath 'net.saliman:gradle-cobertura-plugin:2.6.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
 
-        classpath 'com.google.firebase:firebase-appdistribution-gradle:1.3.1'
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:1.4.0'
 
     }
 }
@@ -25,7 +25,7 @@ subprojects {
         branchName = "${System.getenv("CIRCLE_BRANCH")}"
         buildNumber = "${System.getenv("CIRCLE_BUILD_NUM")}"
     }
-    version = "0.8.2"
+    version = "0.9.0"
     group = "net.pubnative"
 }
 

--- a/hybid.adapters.admob/build.gradle
+++ b/hybid.adapters.admob/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':hybid.sdk')
-    compileOnly 'com.google.android.gms:play-services-ads:18.2.0'
+    compileOnly 'com.google.android.gms:play-services-ads:19.1.0'
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/hybid.adapters.dfp/build.gradle
+++ b/hybid.adapters.dfp/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':hybid.sdk')
-    compileOnly 'com.google.android.gms:play-services-ads:18.2.0'
+    compileOnly 'com.google.android.gms:play-services-ads:19.1.0'
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/hybid.adapters.mopub/build.gradle
+++ b/hybid.adapters.mopub/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':hybid.sdk')
-    compileOnly('com.mopub:mopub-sdk:5.11.0@aar') {
+    compileOnly('com.mopub:mopub-sdk:5.12.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -52,16 +52,16 @@ dependencies {
     implementation project(':hybid.adapters.dfp')
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
-    implementation 'com.google.android.material:material:1.2.0-alpha04'
+    implementation 'com.google.android.material:material:1.2.0-alpha06'
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation('com.mopub:mopub-sdk:5.11.0@aar') {
+    implementation('com.mopub:mopub-sdk:5.12.0@aar') {
         transitive = true
         exclude module: 'libAvid-mopub' // To exclude AVID
         exclude module: 'moat-mobile-app-kit' // To exclude Moat
     }
 
-    implementation 'com.google.android.gms:play-services-ads:18.3.0'
+    implementation 'com.google.android.gms:play-services-ads:19.1.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
@@ -119,7 +119,7 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
     }
 
     // ---------------- MoPub Banner Listener ---------------------
-    override fun onBannerLoaded(banner: MoPubView?) {
+    override fun onBannerLoaded(banner: MoPubView) {
         Log.d(TAG, "onAdLoaded")
     }
 

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubLeaderboardFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubLeaderboardFragment.kt
@@ -94,7 +94,7 @@ class MoPubLeaderboardFragment : Fragment(), RequestManager.RequestListener, MoP
     }
 
     // ---------------- MoPub Banner Listener ---------------------
-    override fun onBannerLoaded(banner: MoPubView?) {
+    override fun onBannerLoaded(banner: MoPubView) {
         Log.d(TAG, "onAdLoaded")
     }
 

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
@@ -119,7 +119,7 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
     }
 
     // ---------------- MoPub Banner Listener ---------------------
-    override fun onBannerLoaded(banner: MoPubView?) {
+    override fun onBannerLoaded(banner: MoPubView) {
         Log.d(TAG, "onAdLoaded")
     }
 

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMediationBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMediationBannerFragment.kt
@@ -48,7 +48,7 @@ class MoPubMediationBannerFragment : Fragment(), MoPubView.BannerAdListener {
     }
 
     // ---------------- MoPub Banner Listener ---------------------
-    override fun onBannerLoaded(banner: MoPubView?) {
+    override fun onBannerLoaded(banner: MoPubView) {
         Log.d(TAG, "onAdLoaded")
         displayLogs()
     }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMediationLeaderboardFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMediationLeaderboardFragment.kt
@@ -48,7 +48,7 @@ class MoPubMediationLeaderboardFragment : Fragment(), MoPubView.BannerAdListener
     }
 
     // ---------------- MoPub Banner Listener ---------------------
-    override fun onBannerLoaded(banner: MoPubView?) {
+    override fun onBannerLoaded(banner: MoPubView) {
         Log.d(TAG, "onAdLoaded")
         displayLogs()
     }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMediationMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMediationMRectFragment.kt
@@ -48,7 +48,7 @@ class MoPubMediationMRectFragment : Fragment(), MoPubView.BannerAdListener {
     }
 
     // ---------------- MoPub Banner Listener ---------------------
-    override fun onBannerLoaded(banner: MoPubView?) {
+    override fun onBannerLoaded(banner: MoPubView) {
         Log.d(TAG, "onAdLoaded")
         displayLogs()
     }


### PR DESCRIPTION
This PR contains the following changes:

- Bump HyBid version to 0.9.0
- Update MoPub SDK to 5.12.0
- Update Admob SDK to 19.1.0
- Prepare for release without crash tracker