### PR TITLE
Fix condition to declare no fill on Vast parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
         branchName = "${System.getenv("CIRCLE_BRANCH")}"
         buildNumber = "${System.getenv("CIRCLE_BUILD_NUM")}"
     }
-    version = "0.9.2"
+    version = "0.9.3"
     group = "net.pubnative"
 }
 

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/vpaid/response/VastProcessor.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/vpaid/response/VastProcessor.java
@@ -53,7 +53,9 @@ public class VastProcessor {
     public void parseResponse(String response, final Listener listener) {
         try {
             Vast vast = XmlParser.parse(response, Vast.class);
-            if (vast.getStatus() == null || vast.getStatus().getText().equalsIgnoreCase("NO_AD")) {
+            if ((vast.getStatus() == null
+                    || vast.getStatus().getText().equalsIgnoreCase("NO_AD"))
+                    && vast.getAd() == null) {
                 PlayerInfo info = new PlayerInfo("No ads found");
                 info.setNoAdsFound();
                 listener.onParseError(info);


### PR DESCRIPTION
This PR contains the following changes:

- Add condition to declare no fill for VAST videos. In some cases there's an ad but no status flag.