### PR TITLE
[OMA-739] Use APIv3 asset size for interstitial framing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'net.saliman:gradle-cobertura-plugin:3.0.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
 
-        classpath 'com.google.firebase:firebase-appdistribution-gradle:1.4.1'
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:2.0.0'
 
     }
 }

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -51,8 +51,8 @@ dependencies {
     implementation project(':hybid.adapters.admob')
     implementation project(':hybid.adapters.dfp')
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta6'
+    implementation 'com.google.android.material:material:1.3.0-alpha01'
     implementation 'androidx.multidex:multidex:2.0.1'
 
     implementation('com.mopub:mopub-sdk:5.12.0@aar') {

--- a/hybid.sdk/src/main/AndroidManifest.xml
+++ b/hybid.sdk/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <application>
         <activity android:name=".consent.UserConsentActivity" />
         <activity android:name=".interstitial.activity.MraidInterstitialActivity" />
+        <activity android:name=".interstitial.activity.CenteredMraidInterstitialActivity" />
         <activity android:name=".interstitial.activity.VastInterstitialActivity" />
     </application>
 </manifest>

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/interstitial/activity/CenteredMraidInterstitialActivity.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/interstitial/activity/CenteredMraidInterstitialActivity.java
@@ -1,0 +1,148 @@
+package net.pubnative.lite.sdk.interstitial.activity;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import net.pubnative.lite.sdk.interstitial.HyBidInterstitialBroadcastReceiver;
+import net.pubnative.lite.sdk.models.APIAsset;
+import net.pubnative.lite.sdk.mraid.MRAIDBanner;
+import net.pubnative.lite.sdk.mraid.MRAIDNativeFeature;
+import net.pubnative.lite.sdk.mraid.MRAIDNativeFeatureListener;
+import net.pubnative.lite.sdk.mraid.MRAIDView;
+import net.pubnative.lite.sdk.mraid.MRAIDViewCloseLayoutListener;
+import net.pubnative.lite.sdk.mraid.MRAIDViewListener;
+import net.pubnative.lite.sdk.utils.ViewUtils;
+
+public class CenteredMraidInterstitialActivity extends HyBidInterstitialActivity implements MRAIDViewListener, MRAIDNativeFeatureListener, MRAIDViewCloseLayoutListener {
+    private String[] mSupportedNativeFeatures = new String[]{
+            MRAIDNativeFeature.CALENDAR,
+            MRAIDNativeFeature.INLINE_VIDEO,
+            MRAIDNativeFeature.SMS,
+            MRAIDNativeFeature.STORE_PICTURE,
+            MRAIDNativeFeature.TEL
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View getAdView() {
+        MRAIDBanner adView = null;
+        FrameLayout container = new FrameLayout(this);
+        container.setBackgroundColor(Color.WHITE);
+        if (getAd() != null) {
+
+            if (getAd().getAssetUrl(APIAsset.HTML_BANNER) != null) {
+                adView = new MRAIDBanner(this, getAd().getAssetUrl(APIAsset.HTML_BANNER), "", mSupportedNativeFeatures,
+                        this, this, getAd().getContentInfoContainer(this));
+            } else if (getAd().getAssetHtml(APIAsset.HTML_BANNER) != null) {
+                adView = new MRAIDBanner(this, "", getAd().getAssetHtml(APIAsset.HTML_BANNER), mSupportedNativeFeatures,
+                        this, this, getAd().getContentInfoContainer(this));
+            }
+
+            int width = getAd().getAssetWidth(APIAsset.HTML_BANNER);
+            if (width == -1) {
+                width = 320;
+            }
+
+            int height = getAd().getAssetHeight(APIAsset.HTML_BANNER);
+            if (height == -1) {
+                height = 480;
+            }
+
+            if (adView != null) {
+                adView.setCloseLayoutListener(this);
+            }
+
+            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
+                    (int) ViewUtils.convertDpToPixel(width, this),
+                    (int) ViewUtils.convertDpToPixel(height, this));
+            layoutParams.gravity = Gravity.CENTER;
+
+            container.addView(adView, layoutParams);
+        }
+        return container;
+    }
+
+    @Override
+    protected boolean shouldShowContentInfo() {
+        return false;
+    }
+
+// ----------------------------------- MRAIDViewListener ---------------------------------------
+
+    @Override
+    public void mraidViewLoaded(MRAIDView mraidView) {
+        getBroadcastSender().sendBroadcast(HyBidInterstitialBroadcastReceiver.Action.SHOW);
+    }
+
+    @Override
+    public void mraidViewExpand(MRAIDView mraidView) {
+
+    }
+
+    @Override
+    public void mraidViewClose(MRAIDView mraidView) {
+
+    }
+
+    @Override
+    public boolean mraidViewResize(MRAIDView mraidView, int width, int height, int offsetX, int offsetY) {
+        return true;
+    }
+
+    // ------------------------------- MRAIDNativeFeatureListener ----------------------------------
+
+    @Override
+    public void mraidNativeFeatureCallTel(String url) {
+
+    }
+
+    @Override
+    public void mraidNativeFeatureCreateCalendarEvent(String eventJSON) {
+
+    }
+
+    @Override
+    public void mraidNativeFeaturePlayVideo(String url) {
+
+    }
+
+    @Override
+    public void mraidNativeFeatureOpenBrowser(String url) {
+        getBroadcastSender().sendBroadcast(HyBidInterstitialBroadcastReceiver.Action.CLICK);
+        getUrlHandler().handleUrl(url);
+    }
+
+    @Override
+    public void mraidNativeFeatureStorePicture(String url) {
+
+    }
+
+    @Override
+    public void mraidNativeFeatureSendSms(String url) {
+
+    }
+
+    // ------------------------------ MRAIDViewCloseLayoutListener ---------------------------------
+
+    @Override
+    public void onShowCloseLayout() {
+        showInterstitialCloseButton();
+    }
+
+    @Override
+    public void onRemoveCloseLayout() {
+        hideInterstitialCloseButton();
+    }
+
+    @Override
+    public void onClose() {
+        dismiss();
+    }
+}

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/interstitial/presenter/MraidInterstitialPresenter.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/interstitial/presenter/MraidInterstitialPresenter.java
@@ -26,8 +26,10 @@ import android.content.Context;
 import android.content.Intent;
 
 import net.pubnative.lite.sdk.interstitial.HyBidInterstitialBroadcastReceiver;
+import net.pubnative.lite.sdk.interstitial.activity.CenteredMraidInterstitialActivity;
 import net.pubnative.lite.sdk.interstitial.activity.HyBidInterstitialActivity;
 import net.pubnative.lite.sdk.interstitial.activity.MraidInterstitialActivity;
+import net.pubnative.lite.sdk.models.APIAsset;
 import net.pubnative.lite.sdk.models.Ad;
 import net.pubnative.lite.sdk.utils.CheckUtils;
 
@@ -93,7 +95,14 @@ public class MraidInterstitialPresenter implements InterstitialPresenter, HyBidI
         if (mBroadcastReceiver != null) {
             mBroadcastReceiver.register();
 
-            Intent intent = new Intent(mContext, MraidInterstitialActivity.class);
+            Intent intent;
+            if (mAd.getAssetWidth(APIAsset.HTML_BANNER) != -1
+                    && mAd.getAssetHeight(APIAsset.HTML_BANNER) != -1) {
+                intent = new Intent(mContext, CenteredMraidInterstitialActivity.class);
+            } else {
+                intent = new Intent(mContext, MraidInterstitialActivity.class);
+            }
+
             intent.putExtra(HyBidInterstitialActivity.EXTRA_BROADCAST_ID, mBroadcastReceiver.getBroadcastId());
             intent.putExtra(HyBidInterstitialActivity.EXTRA_ZONE_ID, mZoneId);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/Ad.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/Ad.java
@@ -159,6 +159,24 @@ public class Ad extends JsonModel implements Serializable {
         return result;
     }
 
+    public int getAssetWidth(String asset) {
+        int result = -1;
+        AdData data = getAsset(asset);
+        if (data != null) {
+            result = data.getWidth();
+        }
+        return result;
+    }
+
+    public int getAssetHeight(String asset) {
+        int result = -1;
+        AdData data = getAsset(asset);
+        if (data != null) {
+            result = data.getHeight();
+        }
+        return result;
+    }
+
     public String getVast() {
         String result = null;
         AdData data = getAsset(APIAsset.VAST);

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdData.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdData.java
@@ -65,6 +65,14 @@ public class AdData extends JsonModel implements Serializable {
         return getStringField("html");
     }
 
+    public int getWidth() {
+        return getIntField("w");
+    }
+
+    public int getHeight() {
+        return getIntField("h");
+    }
+
     public String getStringField(String field) {
 
         return (String) getDataField(field);

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/ViewUtils.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/ViewUtils.java
@@ -73,4 +73,12 @@ public class ViewUtils {
     public static int asIntPixels(float dips, Context context) {
         return (int) (asFloatPixels(dips, context) + 0.5f);
     }
+
+    public static float convertDpToPixel(float dp, Context context){
+        return dp * ((float) context.getResources().getDisplayMetrics().densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+    }
+
+    public static float convertPixelsToDp(float px, Context context){
+        return px / ((float) context.getResources().getDisplayMetrics().densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+    }
 }


### PR DESCRIPTION
This PR contains the following changes

- Add centered interstitial activity to HyBid
- Add methods to get asset size on APIv3 ad model
- Use sizes to determine if fullscreen or framed interstitial should be used