### PR TITLE
[OMA-750] Add MoPub loggin and initialisation adapter to 5.13 update

### DIFF
--- a/hybid.adapters.mopub/src/main/java/com/mopub/mobileads/HyBidAdapterConfiguration.java
+++ b/hybid.adapters.mopub/src/main/java/com/mopub/mobileads/HyBidAdapterConfiguration.java
@@ -1,0 +1,84 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package com.mopub.mobileads;
+
+import android.app.Application;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.mopub.common.BaseAdapterConfiguration;
+import com.mopub.common.OnNetworkInitializationFinishedListener;
+
+import net.pubnative.lite.sdk.HyBid;
+
+import java.util.Map;
+
+public class HyBidAdapterConfiguration extends BaseAdapterConfiguration {
+    private static final String NETWORK_NAME = "pubnative";
+    private static final String NETWORK_SDK_VERSION = BuildConfig.VERSION_NAME;
+    private static final String ADAPTER_VERSION = NETWORK_SDK_VERSION + ".0";
+
+    public static final String CONFIG_KEY_APP_TOKEN = "pubnative_app_token";
+
+
+    @NonNull
+    @Override
+    public String getAdapterVersion() {
+        return ADAPTER_VERSION;
+    }
+
+    @Nullable
+    @Override
+    public String getBiddingToken(@NonNull Context context) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public String getMoPubNetworkName() {
+        return NETWORK_NAME;
+    }
+
+    @NonNull
+    @Override
+    public String getNetworkSdkVersion() {
+        return NETWORK_SDK_VERSION;
+    }
+
+    @Override
+    public void initializeNetwork(@NonNull Context context, @Nullable Map<String, String> configuration, @NonNull final OnNetworkInitializationFinishedListener listener) {
+        if (configuration != null && configuration.containsKey(CONFIG_KEY_APP_TOKEN)) {
+            String appToken = configuration.get(CONFIG_KEY_APP_TOKEN);
+            HyBid.initialize(appToken, (Application) context.getApplicationContext(), new HyBid.InitialisationListener() {
+                @Override
+                public void onInitialisationFinished(boolean success) {
+                    listener.onNetworkInitializationFinished(HyBidAdapterConfiguration.class, MoPubErrorCode.ADAPTER_INITIALIZATION_SUCCESS);
+                }
+            });
+        } else {
+            listener.onNetworkInitializationFinished(HyBidAdapterConfiguration.class, MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
+        }
+    }
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubBannerCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubBannerCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -79,6 +80,7 @@ public class HyBidMoPubBannerCustomEvent extends BaseAd implements AdPresenter.L
         }
 
         mAdPresenter.load();
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
@@ -111,17 +113,20 @@ public class HyBidMoPubBannerCustomEvent extends BaseAd implements AdPresenter.L
     @Override
     public void onAdLoaded(AdPresenter adPresenter, View banner) {
         mAdView = banner;
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
         mAdPresenter.startTracking();
     }
 
     @Override
     public void onAdError(AdPresenter adPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.INTERNAL_ERROR);
     }
 
     @Override
     public void onAdClicked(AdPresenter adPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubInterstitialCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubInterstitialCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -78,12 +79,14 @@ public class HyBidMoPubInterstitialCustomEvent extends BaseAd implements Interst
 
         setAutomaticImpressionAndClickTracking(false);
         mInterstitialPresenter.load();
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
     protected void show() {
         if (mInterstitialPresenter != null) {
             mInterstitialPresenter.show();
+            MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_ATTEMPTED, TAG);
         }
     }
 
@@ -109,26 +112,31 @@ public class HyBidMoPubInterstitialCustomEvent extends BaseAd implements Interst
 
     @Override
     public void onInterstitialLoaded(InterstitialPresenter interstitialPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
     }
 
     @Override
     public void onInterstitialError(InterstitialPresenter interstitialPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.INTERNAL_ERROR);
     }
 
     @Override
     public void onInterstitialShown(InterstitialPresenter interstitialPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_SUCCESS, TAG);
         mInteractionListener.onAdShown();
     }
 
     @Override
     public void onInterstitialClicked(InterstitialPresenter interstitialPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 
     @Override
     public void onInterstitialDismissed(InterstitialPresenter interstitialPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.DID_DISAPPEAR, TAG);
         mInteractionListener.onAdDismissed();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubLeaderboardCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubLeaderboardCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -81,6 +82,7 @@ public class HyBidMoPubLeaderboardCustomEvent extends BaseAd implements AdPresen
         }
 
         mLeaderboardPresenter.load();
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
@@ -113,17 +115,20 @@ public class HyBidMoPubLeaderboardCustomEvent extends BaseAd implements AdPresen
     @Override
     public void onAdLoaded(AdPresenter adPresenter, View banner) {
         mAdView = banner;
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
         mLeaderboardPresenter.startTracking();
     }
 
     @Override
     public void onAdError(AdPresenter adPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.INTERNAL_ERROR);
     }
 
     @Override
     public void onAdClicked(AdPresenter adPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubMRectCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubMRectCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.AdLifecycleListener;
 import com.mopub.mobileads.BaseAd;
@@ -82,6 +83,7 @@ public class HyBidMoPubMRectCustomEvent extends BaseAd implements AdPresenter.Li
         }
 
         mMRectPresenter.load();
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
@@ -114,17 +116,20 @@ public class HyBidMoPubMRectCustomEvent extends BaseAd implements AdPresenter.Li
     @Override
     public void onAdLoaded(AdPresenter adPresenter, View banner) {
         mAdView = banner;
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
         mMRectPresenter.startTracking();
     }
 
     @Override
     public void onAdError(AdPresenter adPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.INTERNAL_ERROR);
     }
 
     @Override
     public void onAdClicked(AdPresenter adPresenter) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationBannerCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationBannerCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -76,6 +77,7 @@ public class HyBidMediationBannerCustomEvent extends BaseAd implements PNAdView.
         mBannerView = new HyBidBannerAdView(context);
         mBannerView.setMediation(true);
         mBannerView.load(mZoneID, this);
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
@@ -112,21 +114,25 @@ public class HyBidMediationBannerCustomEvent extends BaseAd implements PNAdView.
     //------------------------------------ PNAdView Callbacks --------------------------------------
     @Override
     public void onAdLoaded() {
-            mLoadListener.onAdLoaded();
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
+        mLoadListener.onAdLoaded();
     }
 
     @Override
     public void onAdLoadFailed(Throwable error) {
-            mLoadListener.onAdLoadFailed(MoPubErrorCode.NETWORK_NO_FILL);
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
+        mLoadListener.onAdLoadFailed(MoPubErrorCode.NETWORK_NO_FILL);
     }
 
     @Override
     public void onAdImpression() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_SUCCESS, TAG);
         mInteractionListener.onAdImpression();
     }
 
     @Override
     public void onAdClick() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationInterstitialCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationInterstitialCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -74,14 +75,15 @@ public class HyBidMediationInterstitialCustomEvent extends BaseAd implements HyB
         mInterstitialAd = new HyBidInterstitialAd(context, mZoneID, this);
         mInterstitialAd.setMediation(true);
         mInterstitialAd.load();
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
     protected void show() {
         if (mInterstitialAd != null) {
             mInterstitialAd.show();
+            MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_ATTEMPTED, TAG);
         }
-        super.show();
     }
 
     @Override
@@ -107,27 +109,31 @@ public class HyBidMediationInterstitialCustomEvent extends BaseAd implements HyB
     //--------------------------------- PNInterstitialAd Callbacks ---------------------------------
     @Override
     public void onInterstitialLoaded() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
     }
 
     @Override
     public void onInterstitialLoadFailed(Throwable error) {
-        Logger.e(TAG, error.getMessage());
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.NETWORK_NO_FILL);
     }
 
     @Override
     public void onInterstitialImpression() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_SUCCESS, TAG);
         mInteractionListener.onAdImpression();
     }
 
     @Override
     public void onInterstitialDismissed() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.DID_DISAPPEAR, TAG);
         mInteractionListener.onAdDismissed();
     }
 
     @Override
     public void onInterstitialClick() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationLeaderboardCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationLeaderboardCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -76,6 +77,7 @@ public class HyBidMediationLeaderboardCustomEvent extends BaseAd implements PNAd
         mLeaderboardView = new HyBidLeaderboardAdView(context);
         mLeaderboardView.setMediation(true);
         mLeaderboardView.load(mZoneID, this);
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
@@ -112,21 +114,25 @@ public class HyBidMediationLeaderboardCustomEvent extends BaseAd implements PNAd
     //------------------------------------ PNAdView Callbacks --------------------------------------
     @Override
     public void onAdLoaded() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
     }
 
     @Override
     public void onAdLoadFailed(Throwable error) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.NETWORK_NO_FILL);
     }
 
     @Override
     public void onAdImpression() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_SUCCESS, TAG);
         mInteractionListener.onAdImpression();
     }
 
     @Override
     public void onAdClick() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationMRectCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationMRectCustomEvent.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.mobileads.AdData;
 import com.mopub.mobileads.BaseAd;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -76,6 +77,7 @@ public class HyBidMediationMRectCustomEvent extends BaseAd implements PNAdView.L
         mMRectView = new HyBidMRectAdView(context);
         mMRectView.setMediation(true);
         mMRectView.load(mZoneID, this);
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
@@ -112,21 +114,25 @@ public class HyBidMediationMRectCustomEvent extends BaseAd implements PNAdView.L
     //------------------------------------ PNAdView Callbacks --------------------------------------
     @Override
     public void onAdLoaded() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         mLoadListener.onAdLoaded();
     }
 
     @Override
     public void onAdLoadFailed(Throwable error) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         mLoadListener.onAdLoadFailed(MoPubErrorCode.NETWORK_NO_FILL);
     }
 
     @Override
     public void onAdImpression() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_SUCCESS, TAG);
         mInteractionListener.onAdImpression();
     }
 
     @Override
     public void onAdClick() {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
         mInteractionListener.onAdClicked();
     }
 }

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationNativeCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/HyBidMediationNativeCustomEvent.java
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
 package net.pubnative.lite.adapters.mopub.mediation;
 
 import android.content.Context;
@@ -5,6 +27,7 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import com.mopub.common.logging.MoPubLog;
 import com.mopub.nativeads.CustomEventNative;
 import com.mopub.nativeads.ImpressionTracker;
 import com.mopub.nativeads.NativeErrorCode;
@@ -55,15 +78,18 @@ public class HyBidMediationNativeCustomEvent extends CustomEventNative implement
         mAdRequest = new HyBidNativeAdRequest();
         mAdRequest.setMediation(true);
         mAdRequest.load(zoneId, this);
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_ATTEMPTED, TAG);
     }
 
     @Override
     public void onRequestSuccess(NativeAd ad) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_SUCCESS, TAG);
         new HyBidStaticNativeAd(ad, new ImpressionTracker(mContext), mListener);
     }
 
     @Override
     public void onRequestFail(Throwable throwable) {
+        MoPubLog.log(MoPubLog.AdapterLogEvent.LOAD_FAILED, TAG);
         if (mListener != null) {
             mListener.onNativeAdFailed(NativeErrorCode.NETWORK_NO_FILL);
         }
@@ -111,11 +137,13 @@ public class HyBidMediationNativeCustomEvent extends CustomEventNative implement
 
         @Override
         public void onAdImpression(NativeAd ad, View view) {
+            MoPubLog.log(MoPubLog.AdapterLogEvent.SHOW_SUCCESS, TAG);
             notifyAdImpressed();
         }
 
         @Override
         public void onAdClick(NativeAd ad, View view) {
+            MoPubLog.log(MoPubLog.AdapterLogEvent.CLICKED, TAG);
             notifyAdClicked();
         }
     }

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation project(':hybid.adapters.admob')
     implementation project(':hybid.adapters.dfp')
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta6'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta7'
     implementation 'com.google.android.material:material:1.3.0-alpha01'
     implementation 'androidx.multidex:multidex:2.0.1'
 

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/HyBidDemoApplication.java
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/HyBidDemoApplication.java
@@ -65,7 +65,9 @@ public class HyBidDemoApplication extends MultiDexApplication {
         }
         SettingsModel settings = fetchSettings();
 
-        HyBid.initialize(settings.getAppToken(), this, new HyBid.InitialisationListener() {
+        String appToken = settings.getAppToken();
+
+        HyBid.initialize(appToken, this, new HyBid.InitialisationListener() {
             @Override
             public void onInitialisationFinished(boolean success) {
                 // HyBid SDK has been initialised
@@ -78,14 +80,6 @@ public class HyBidDemoApplication extends MultiDexApplication {
         HyBid.setCoppaEnabled(settings.getCoppa());
         HyBid.setAge(settings.getAge());
         HyBid.setGender(settings.getGender());
-
-        HyBid.getViewabilityManager().setViewabilityMeasurementEnabled(true);
-
-        if (!settings.getBrowserPriorities().isEmpty()) {
-            for (String packageName : settings.getBrowserPriorities()) {
-                HyBid.getBrowserManager().addBrowser(packageName);
-            }
-        }
 
         StringBuilder keywordsBuilder = new StringBuilder();
         String separator = ",";
@@ -100,11 +94,20 @@ public class HyBidDemoApplication extends MultiDexApplication {
         }
 
         HyBid.setKeywords(keywordString);
+
+        HyBid.getViewabilityManager().setViewabilityMeasurementEnabled(true);
+
+        if (!settings.getBrowserPriorities().isEmpty()) {
+            for (String packageName : settings.getBrowserPriorities()) {
+                HyBid.getBrowserManager().addBrowser(packageName);
+            }
+        }
+
         if (!TextUtils.isEmpty(settings.getApiUrl())) {
             ApiManager.INSTANCE.setApiUrl(settings.getApiUrl());
         }
 
-        MoPubManager.initMoPubSdk(this, settings.getMopubBannerAdUnitId());
+        MoPubManager.initMoPubSdk(this, appToken, settings.getMopubBannerAdUnitId());
 
         MobileAds.initialize(this, initializationStatus -> {
         });

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/managers/MoPubManager.java
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/managers/MoPubManager.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,23 +28,29 @@ import com.mopub.common.MoPub;
 import com.mopub.common.SdkConfiguration;
 import com.mopub.common.SdkInitializationListener;
 import com.mopub.common.logging.MoPubLog;
+import com.mopub.mobileads.HyBidAdapterConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class MoPubManager {
-    public static void initMoPubSdk(Context context, String adUnitId) {
-        initMoPubSdk(context, adUnitId, null);
+    public static void initMoPubSdk(Context context, String pubnativeAppToken, String adUnitId) {
+        initMoPubSdk(context, pubnativeAppToken, adUnitId, null);
     }
 
-    public static void initMoPubSdk(Context context, String adUnitId, final InitialisationListener listener) {
+    public static void initMoPubSdk(Context context, String pubnativeAppToken, String adUnitId, final InitialisationListener listener) {
+        /*Map<String, String> pubnativeInitConfig = new HashMap<>();
+        pubnativeInitConfig.put(HyBidAdapterConfiguration.CONFIG_KEY_APP_TOKEN, pubnativeAppToken);*/
+
         SdkConfiguration sdkConfiguration = new SdkConfiguration
                 .Builder(adUnitId)
                 .withLogLevel(MoPubLog.LogLevel.DEBUG)
+                //.withAdditionalNetwork(HyBidAdapterConfiguration.class.getName())
+                //.withMediatedNetworkConfiguration(HyBidAdapterConfiguration.class.getName(), pubnativeInitConfig)
                 .build();
-        MoPub.initializeSdk(context, sdkConfiguration, new SdkInitializationListener() {
-            @Override
-            public void onInitializationFinished() {
-                if (listener != null) {
-                    listener.onInitialisationFinished();
-                }
+        MoPub.initializeSdk(context, sdkConfiguration, () -> {
+            if (listener != null) {
+                listener.onInitialisationFinished();
             }
         });
     }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/config/MoPubSettingsFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/config/MoPubSettingsFragment.kt
@@ -88,7 +88,7 @@ class MoPubSettingsFragment : Fragment() {
             settingManager.setMoPubMediationInterstitialAdUnitId(mediationInterstitialAdUnitId)
             settingManager.setMoPubMediationNativeAdUnitId(mediationNativeAdUnitId)
 
-            MoPubManager.initMoPubSdk(activity, bannerAdUnitId) {
+            MoPubManager.initMoPubSdk(activity, settingManager.getSettings().appToken, bannerAdUnitId) {
                 Toast.makeText(activity, "MoPub settings saved successfully.", Toast.LENGTH_SHORT).show()
                 activity?.finish()
             }


### PR DESCRIPTION
This PR contains the following changes:

- Add MoPub event logging to adapters
- Add initialisation adapter for HyBid SDK