### PR TITLE
[OMA-791] MoPub header bidding adapters backwards compatibility

### DIFF
--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubBannerCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubBannerCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingBannerCustomEvent;
+
+public class HyBidMoPubBannerCustomEvent extends HyBidHeaderBiddingBannerCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubInterstitialCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubInterstitialCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingInterstitialCustomEvent;
+
+public class HyBidMoPubInterstitialCustomEvent extends HyBidHeaderBiddingInterstitialCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubLeaderboardCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubLeaderboardCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingLeaderboardCustomEvent;
+
+public class HyBidMoPubLeaderboardCustomEvent extends HyBidHeaderBiddingLeaderboardCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubMRectCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/HyBidMoPubMRectCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingMRectCustomEvent;
+
+public class HyBidMoPubMRectCustomEvent extends HyBidHeaderBiddingMRectCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubBannerCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubBannerCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingBannerCustomEvent;
+
+public class PNLiteMoPubBannerCustomEvent extends HyBidHeaderBiddingBannerCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubInterstitialCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubInterstitialCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingInterstitialCustomEvent;
+
+public class PNLiteMoPubInterstitialCustomEvent extends HyBidHeaderBiddingInterstitialCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubLeaderboardCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubLeaderboardCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingLeaderboardCustomEvent;
+
+public class PNLiteMoPubLeaderboardCustomEvent extends HyBidHeaderBiddingLeaderboardCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubMRectCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/PNLiteMoPubMRectCustomEvent.java
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub;
+
+import net.pubnative.lite.adapters.mopub.headerbidding.HyBidHeaderBiddingMRectCustomEvent;
+
+public class PNLiteMoPubMRectCustomEvent extends HyBidHeaderBiddingMRectCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationBannerCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationBannerCustomEvent.java
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub.mediation;
+
+public class PNLiteMediationBannerCustomEvent extends HyBidMediationBannerCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationInterstitialCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationInterstitialCustomEvent.java
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub.mediation;
+
+public class PNLiteMediationInterstitialCustomEvent extends HyBidMediationInterstitialCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationLeaderboardCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationLeaderboardCustomEvent.java
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub.mediation;
+
+public class PNLiteMediationLeaderboardCustomEvent extends HyBidMediationLeaderboardCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationMRectCustomEvent.java
+++ b/hybid.adapters.mopub/src/main/java/net/pubnative/lite/adapters/mopub/mediation/PNLiteMediationMRectCustomEvent.java
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package net.pubnative.lite.adapters.mopub.mediation;
+
+public class PNLiteMediationMRectCustomEvent extends HyBidMediationMRectCustomEvent {
+    /*
+     *  This class is kept for backwards compatibility.
+     */
+}

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPBannerFragment.kt
@@ -106,12 +106,12 @@ class DFPBannerFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = HeaderBiddingUtils.getPrebidKeywordsSet(ad)
+        val keywordSet = HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = HeaderBiddingUtils.getPrebidKeywordsBundle(ad)
+        val keywordBundle = HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPInterstitialFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPInterstitialFragment.kt
@@ -95,12 +95,12 @@ class DFPInterstitialFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = HeaderBiddingUtils.getPrebidKeywordsSet(ad)
+        val keywordSet = HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = HeaderBiddingUtils.getPrebidKeywordsBundle(ad)
+        val keywordBundle = HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPLeaderboardFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPLeaderboardFragment.kt
@@ -81,12 +81,12 @@ class DFPLeaderboardFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = HeaderBiddingUtils.getPrebidKeywordsSet(ad)
+        val keywordSet = HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = HeaderBiddingUtils.getPrebidKeywordsBundle(ad)
+        val keywordBundle = HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/dfp/DFPMRectFragment.kt
@@ -105,12 +105,12 @@ class DFPMRectFragment : Fragment(), RequestManager.RequestListener {
     override fun onRequestSuccess(ad: Ad?) {
         val builder = PublisherAdRequest.Builder()
 
-        val keywordSet = HeaderBiddingUtils.getPrebidKeywordsSet(ad)
+        val keywordSet = HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad)
         for (key in keywordSet) {
             builder.addKeyword(key)
         }
 
-        val keywordBundle = HeaderBiddingUtils.getPrebidKeywordsBundle(ad)
+        val keywordBundle = HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad)
         for (key in keywordBundle.keySet()) {
             builder.addCustomTargeting(key, keywordBundle.getString(key))
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubBannerFragment.kt
@@ -106,7 +106,7 @@ class MoPubBannerFragment : Fragment(), RequestManager.RequestListener, MoPubVie
 
         adUnitId?.let {
             mopubBanner.setAdUnitId(it)
-            mopubBanner.setKeywords(HeaderBiddingUtils.getPrebidKeywords(ad, HeaderBiddingUtils.KeywordMode.TWO_DECIMALS))
+            mopubBanner.setKeywords(HeaderBiddingUtils.getHeaderBiddingKeywords(ad, HeaderBiddingUtils.KeywordMode.TWO_DECIMALS))
             mopubBanner.adSize = MoPubView.MoPubAdSize.HEIGHT_50
             mopubBanner.loadAd()
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubInterstitialFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubInterstitialFragment.kt
@@ -101,7 +101,7 @@ class MoPubInterstitialFragment : Fragment(), RequestManager.RequestListener, Mo
 
     // --------------- HyBid Request Listener --------------------
     override fun onRequestSuccess(ad: Ad?) {
-        mopubInterstitial.setKeywords(HeaderBiddingUtils.getPrebidKeywords(ad))
+        mopubInterstitial.setKeywords(HeaderBiddingUtils.getHeaderBiddingKeywords(ad))
         mopubInterstitial.load()
 
         Log.d(TAG, "onRequestSuccess")

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubLeaderboardFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubLeaderboardFragment.kt
@@ -80,7 +80,7 @@ class MoPubLeaderboardFragment : Fragment(), RequestManager.RequestListener, MoP
         displayLogs()
         adUnitId?.let {
             mopubLeaderboard.setAdUnitId(it)
-            mopubLeaderboard.setKeywords(HeaderBiddingUtils.getPrebidKeywords(ad))
+            mopubLeaderboard.setKeywords(HeaderBiddingUtils.getHeaderBiddingKeywords(ad))
             mopubLeaderboard.adSize = MoPubView.MoPubAdSize.HEIGHT_90
             mopubLeaderboard.loadAd()
         }

--- a/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
+++ b/hybid.demo/src/main/java/net/pubnative/lite/demo/ui/fragments/mopub/MoPubMRectFragment.kt
@@ -105,7 +105,7 @@ class MoPubMRectFragment : Fragment(), RequestManager.RequestListener, MoPubView
         displayLogs()
         adUnitId?.let {
             mopubMRect.setAdUnitId(it)
-            mopubMRect.setKeywords(HeaderBiddingUtils.getPrebidKeywords(ad))
+            mopubMRect.setKeywords(HeaderBiddingUtils.getHeaderBiddingKeywords(ad))
             mopubMRect.adSize = MoPubView.MoPubAdSize.HEIGHT_250
             mopubMRect.loadAd()
         }

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/HeaderBiddingUtils.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/HeaderBiddingUtils.java
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2018 PubNative GmbH
+// Copyright (c) 2020 PubNative GmbH
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -57,19 +57,19 @@ public class HeaderBiddingUtils {
     }
 
     //---------------------------------- String keywords -------------------------------------------
-    public static String getPrebidKeywords(Ad ad) {
-        return getPrebidKeywords(ad, "");
+    public static String getHeaderBiddingKeywords(Ad ad) {
+        return getHeaderBiddingKeywords(ad, "");
     }
 
-    public static String getPrebidKeywords(Ad ad, KeywordMode mode) {
-        return getPrebidKeywords(ad, "", mode);
+    public static String getHeaderBiddingKeywords(Ad ad, KeywordMode mode) {
+        return getHeaderBiddingKeywords(ad, "", mode);
     }
 
-    public static String getPrebidKeywords(Ad ad, String zoneId) {
-        return getPrebidKeywords(ad, zoneId, KeywordMode.THREE_DECIMALS);
+    public static String getHeaderBiddingKeywords(Ad ad, String zoneId) {
+        return getHeaderBiddingKeywords(ad, zoneId, KeywordMode.THREE_DECIMALS);
     }
 
-    public static String getPrebidKeywords(Ad ad, String zoneId, KeywordMode mode) {
+    public static String getHeaderBiddingKeywords(Ad ad, String zoneId, KeywordMode mode) {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(KEYS.PN_BID).append(':').append(getBidECPM(ad, mode));
@@ -78,19 +78,19 @@ public class HeaderBiddingUtils {
     }
 
     //---------------------------------- Bundle keywords -------------------------------------------
-    public static Bundle getPrebidKeywordsBundle(Ad ad) {
-        return getPrebidKeywordsBundle(ad, "");
+    public static Bundle getHeaderBiddingKeywordsBundle(Ad ad) {
+        return getHeaderBiddingKeywordsBundle(ad, "");
     }
 
-    public static Bundle getPrebidKeywordsBundle(Ad ad, KeywordMode mode) {
-        return getPrebidKeywordsBundle(ad, "", mode);
+    public static Bundle getHeaderBiddingKeywordsBundle(Ad ad, KeywordMode mode) {
+        return getHeaderBiddingKeywordsBundle(ad, "", mode);
     }
 
-    public static Bundle getPrebidKeywordsBundle(Ad ad, String zoneid) {
-        return getPrebidKeywordsBundle(ad, zoneid, KeywordMode.THREE_DECIMALS);
+    public static Bundle getHeaderBiddingKeywordsBundle(Ad ad, String zoneid) {
+        return getHeaderBiddingKeywordsBundle(ad, zoneid, KeywordMode.THREE_DECIMALS);
     }
 
-    public static Bundle getPrebidKeywordsBundle(Ad ad, String zoneid, KeywordMode mode) {
+    public static Bundle getHeaderBiddingKeywordsBundle(Ad ad, String zoneid, KeywordMode mode) {
         Bundle bundle = new Bundle();
 
         bundle.putString(KEYS.PN_BID, getBidECPM(ad, mode));
@@ -99,19 +99,19 @@ public class HeaderBiddingUtils {
     }
 
     //------------------------------------ Set keywords --------------------------------------------
-    public static Set<String> getPrebidKeywordsSet(Ad ad) {
-        return getPrebidKeywordsSet(ad, "");
+    public static Set<String> getHeaderBiddingKeywordsSet(Ad ad) {
+        return getHeaderBiddingKeywordsSet(ad, "");
     }
 
-    public static Set<String> getPrebidKeywordsSet(Ad ad, KeywordMode mode) {
-        return getPrebidKeywordsSet(ad, "", mode);
+    public static Set<String> getHeaderBiddingKeywordsSet(Ad ad, KeywordMode mode) {
+        return getHeaderBiddingKeywordsSet(ad, "", mode);
     }
 
-    public static Set<String> getPrebidKeywordsSet(Ad ad, String zoneid) {
-        return getPrebidKeywordsSet(ad, zoneid, KeywordMode.THREE_DECIMALS);
+    public static Set<String> getHeaderBiddingKeywordsSet(Ad ad, String zoneid) {
+        return getHeaderBiddingKeywordsSet(ad, zoneid, KeywordMode.THREE_DECIMALS);
     }
 
-    public static Set<String> getPrebidKeywordsSet(Ad ad, String zoneid, KeywordMode mode) {
+    public static Set<String> getHeaderBiddingKeywordsSet(Ad ad, String zoneid, KeywordMode mode) {
         Set<String> set = new LinkedHashSet<>(3);
 
         set.add(KEYS.PN_BID.concat(":").concat(getBidECPM(ad, mode)));

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/PrebidUtils.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/utils/PrebidUtils.java
@@ -1,43 +1,87 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 PubNative GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
 package net.pubnative.lite.sdk.utils;
 
 import android.os.Bundle;
 
 import net.pubnative.lite.sdk.models.Ad;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
-public class PrebidUtils extends HeaderBiddingUtils {
+public class PrebidUtils {
     public enum KeywordMode {
         TWO_DECIMALS, THREE_DECIMALS
     }
 
     //---------------------------------- String keywords -------------------------------------------
+    public static String getPrebidKeywords(Ad ad) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywords(ad);
+    }
+
     public static String getPrebidKeywords(Ad ad, KeywordMode mode) {
-        return getPrebidKeywords(ad, "", mapKeywordMode(mode));
+        return HeaderBiddingUtils.getHeaderBiddingKeywords(ad, mapKeywordMode(mode));
+    }
+
+    public static String getPrebidKeywords(Ad ad, String zoneId) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywords(ad, zoneId);
     }
 
     public static String getPrebidKeywords(Ad ad, String zoneId, KeywordMode mode) {
-        return getPrebidKeywords(ad, zoneId, mapKeywordMode(mode));
+        return HeaderBiddingUtils.getHeaderBiddingKeywords(ad, zoneId, mapKeywordMode(mode));
     }
 
     //---------------------------------- Bundle keywords -------------------------------------------
-
-    public static Bundle getPrebidKeywordsBundle(Ad ad, KeywordMode mode) {
-        return getPrebidKeywordsBundle(ad, "", mapKeywordMode(mode));
+    public static Bundle getPrebidKeywordsBundle(Ad ad) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad);
     }
 
-    public static Bundle getPrebidKeywordsBundle(Ad ad, String zoneId, KeywordMode mode) {
-        return getPrebidKeywordsBundle(ad, zoneId, mapKeywordMode(mode));
+    public static Bundle getPrebidKeywordsBundle(Ad ad, KeywordMode mode) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad, mapKeywordMode(mode));
+    }
+
+    public static Bundle getPrebidKeywordsBundle(Ad ad, String zoneid) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad, zoneid);
+    }
+
+    public static Bundle getPrebidKeywordsBundle(Ad ad, String zoneid, KeywordMode mode) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsBundle(ad, zoneid, mapKeywordMode(mode));
     }
 
     //------------------------------------ Set keywords --------------------------------------------
-    public static Set<String> getPrebidKeywordsSet(Ad ad, KeywordMode mode) {
-        return getPrebidKeywordsSet(ad, "", mapKeywordMode(mode));
+    public static Set<String> getPrebidKeywordsSet(Ad ad) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad);
     }
 
-    public static Set<String> getPrebidKeywordsSet(Ad ad, String zoneId, KeywordMode mode) {
-        return getPrebidKeywordsSet(ad, zoneId, mapKeywordMode(mode));
+    public static Set<String> getPrebidKeywordsSet(Ad ad, KeywordMode mode) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad, mapKeywordMode(mode));
+    }
+
+    public static Set<String> getPrebidKeywordsSet(Ad ad, String zoneid) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad, zoneid);
+    }
+
+    public static Set<String> getPrebidKeywordsSet(Ad ad, String zoneid, KeywordMode mode) {
+        return HeaderBiddingUtils.getHeaderBiddingKeywordsSet(ad, zoneid, mapKeywordMode(mode));
     }
 
     /*


### PR DESCRIPTION
This PR contains the following changes:
- Add back old header bidding adapters for backwards compatibility
- Refactor method names on HeaderBiddingUtils class