### PR TITLE
[OMA-814] Update gradle android plugin 4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,16 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url 'https://dl.bintray.com/pubnative/maven' }
         maven { url 'https://maven.ogury.co' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-        classpath 'net.saliman:gradle-cobertura-plugin:3.0.0'
+        classpath 'net.saliman:gradle-cobertura-plugin:3.0.1-SNAPSHOT'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
 
         classpath 'com.google.firebase:firebase-appdistribution-gradle:2.0.1'
@@ -35,7 +35,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url 'https://dl.bintray.com/pubnative/maven' }
         maven { url 'https://maven.ogury.co' }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 29 10:44:55 CEST 2020
+#Tue Oct 13 10:52:59 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation project(':hybid.adapters.admob')
     implementation project(':hybid.adapters.dfp')
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'com.google.android.material:material:1.3.0-alpha03'
     implementation 'androidx.multidex:multidex:2.0.1'
 

--- a/hybid.sdk/build.gradle
+++ b/hybid.sdk/build.gradle
@@ -31,10 +31,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'lite.sdk.pro'
             buildConfigField "String", "OMIDPV", "\"$omid_version\""
             buildConfigField "String", "OMIDPN", "\"pubnativenet\""
+            buildConfigField "String", "SDK_VERSION", "\"$version_name\""
         }
         debug {
             buildConfigField "String", "OMIDPV", "\"$omid_version\""
             buildConfigField "String", "OMIDPN", "\"pubnativenet\""
+            buildConfigField "String", "SDK_VERSION", "\"$version_name\""
         }
     }
 }

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdRequestFactory.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdRequestFactory.java
@@ -151,7 +151,7 @@ public class AdRequestFactory {
 
         adRequest.displaymanager = "HyBid";
         adRequest.displaymanagerver = String.format(Locale.ENGLISH, "%s_%s_%s",
-                "sdkandroid", integrationType.getCode(), BuildConfig.VERSION_NAME);
+                "sdkandroid", integrationType.getCode(), BuildConfig.SDK_VERSION);
 
         if (mLocationManager != null) {
             Location location = mLocationManager.getUserLocation();

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/viewability/ViewabilityManager.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/viewability/ViewabilityManager.java
@@ -34,7 +34,7 @@ public class ViewabilityManager {
 
                 if (Omid.isActive() && mPubNativePartner == null) {
                     try {
-                        mPubNativePartner = Partner.createPartner(VIEWABILITY_PARTNER_NAME, BuildConfig.VERSION_NAME);
+                        mPubNativePartner = Partner.createPartner(VIEWABILITY_PARTNER_NAME, BuildConfig.SDK_VERSION);
                     } catch (IllegalArgumentException e) {
                         e.printStackTrace();
                     }

--- a/hybid.sdk/src/test/java/net/pubnative/lite/sdk/models/AdRequestFactoryTest.java
+++ b/hybid.sdk/src/test/java/net/pubnative/lite/sdk/models/AdRequestFactoryTest.java
@@ -90,6 +90,6 @@ public class AdRequestFactoryTest {
         Assert.assertEquals(HyBid.OM_PARTNER_NAME, request.omidpn);
 
         Assert.assertEquals(String.format(Locale.ENGLISH, "%s_%s_%s",
-                "sdkandroid", "hb", BuildConfig.VERSION_NAME), request.displaymanagerver);
+                "sdkandroid", "hb", BuildConfig.SDK_VERSION), request.displaymanagerver);
     }
 }


### PR DESCRIPTION
This PR contains the following changes:

- Update grade android plugin to version 4.1
- Update cobertura grade plugin to one compatible with the new gradle
- Create SDK_VERSION variable on the build.gradle file to read the reference from the Java code