### PR TITLE
[OMA-810] Check for session finished before reporting volume change

### DIFF
--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/viewability/HyBidViewabilityNativeVideoAdSession.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/viewability/HyBidViewabilityNativeVideoAdSession.java
@@ -169,7 +169,7 @@ public class HyBidViewabilityNativeVideoAdSession extends HyBidViewabilityNative
         if (!HyBid.getViewabilityManager().isViewabilityMeasurementEnabled())
             return;
 
-        if (mMediaEvents != null) {
+        if (mMediaEvents != null && !completeFired) {
             mMediaEvents.volumeChange(mute ? 0 : 1);
         }
     }

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/vpaid/response/VastProcessor.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/vpaid/response/VastProcessor.java
@@ -187,7 +187,9 @@ public class VastProcessor {
                     List<Companion> companionList = getSortedCompanions(creativeList);
                     List<String> endCardUrlList = new ArrayList<>();
                     for (Companion companion : companionList) {
-                        endCardUrlList.add(companion.getStaticResource().getText().trim());
+                        if (companion.getStaticResource() != null && !TextUtils.isEmpty(companion.getStaticResource().getText())) {
+                            endCardUrlList.add(companion.getStaticResource().getText().trim());
+                        }
                     }
                     adParams.setEndCardUrlList(endCardUrlList);
 


### PR DESCRIPTION
This PR contains the following changes:

- Stop from notifying volume changes to OM SDK if the ad session is over
- Null check for StaticResource object for companion ads 