### PR TITLE
[OMA-863] Clean up user data with negative consent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
         buildNumber = "${System.getenv("CIRCLE_BUILD_NUM")}"
         omid_version = '1.3.10'
     }
-    version = "2.2.1"
+    version = "2.2.2"
     group = "net.pubnative"
 }
 

--- a/hybid.adapters.admob/build.gradle
+++ b/hybid.adapters.admob/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':hybid.sdk')
-    compileOnly 'com.google.android.gms:play-services-ads:19.4.0'
+    compileOnly 'com.google.android.gms:play-services-ads:19.5.0'
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/hybid.adapters.dfp/build.gradle
+++ b/hybid.adapters.dfp/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':hybid.sdk')
-    compileOnly 'com.google.android.gms:play-services-ads:19.4.0'
+    compileOnly 'com.google.android.gms:play-services-ads:19.5.0'
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/hybid.demo/build.gradle
+++ b/hybid.demo/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation project(':hybid.adapters.admob')
     implementation project(':hybid.adapters.dfp')
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'com.google.android.material:material:1.3.0-alpha03'
     implementation 'androidx.multidex:multidex:2.0.1'
 
@@ -64,7 +64,7 @@ dependencies {
         transitive = true
     }
 
-    implementation 'com.google.android.gms:play-services-ads:19.4.0'
+    implementation 'com.google.android.gms:play-services-ads:19.5.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/UserDataManager.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/UserDataManager.java
@@ -111,6 +111,14 @@ public class UserDataManager {
         }
     }
 
+    /**]
+     * Only for internal use in the ad request
+     * @return if consent has explicitly been denied.
+     */
+    public boolean isConsentDenied() {
+        return mPreferences.contains(KEY_GDPR_CONSENT_STATE) && mPreferences.getInt(KEY_GDPR_CONSENT_STATE, CONSENT_STATE_DENIED) == CONSENT_STATE_DENIED;
+    }
+
     /**
      * This method is being deprecated
      *
@@ -142,6 +150,7 @@ public class UserDataManager {
     }
 
     private void notifyConsentGiven() {
+        setConsentState(CONSENT_STATE_ACCEPTED);
         UserConsentRequestModel requestModel = new UserConsentRequestModel(
                 HyBid.getDeviceInfo().getAdvertisingId(),
                 DEVICE_ID_TYPE, true);
@@ -151,7 +160,7 @@ public class UserDataManager {
             @Override
             public void onSuccess(UserConsentResponseModel model) {
                 if (model.getStatus().equals(UserConsentResponseStatus.OK)) {
-                    setConsentState(CONSENT_STATE_ACCEPTED);
+                    Logger.d(TAG, "Positive user consent has been notified");
                 }
             }
 
@@ -163,6 +172,7 @@ public class UserDataManager {
     }
 
     private void notifyConsentDenied() {
+        setConsentState(CONSENT_STATE_DENIED);
         UserConsentRequestModel requestModel = new UserConsentRequestModel(
                 HyBid.getDeviceInfo().getAdvertisingId(),
                 DEVICE_ID_TYPE, false);
@@ -172,7 +182,7 @@ public class UserDataManager {
             @Override
             public void onSuccess(UserConsentResponseModel model) {
                 if (model.getStatus().equals(UserConsentResponseStatus.OK)) {
-                    setConsentState(CONSENT_STATE_DENIED);
+                    Logger.d(TAG, "Negative user consent has been notified");
                 }
             }
 

--- a/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdRequestFactory.java
+++ b/hybid.sdk/src/main/java/net/pubnative/lite/sdk/models/AdRequestFactory.java
@@ -104,7 +104,7 @@ public class AdRequestFactory {
         adRequest.omidpv = HyBid.OMSDK_VERSION;
 
         if (HyBid.isCoppaEnabled() || limitTracking || TextUtils.isEmpty(advertisingId)
-                || isCCPAOptOut) {
+                || isCCPAOptOut || mUserDataManager.isConsentDenied()) {
             adRequest.dnt = "1";
         } else {
             adRequest.gid = advertisingId;
@@ -125,7 +125,7 @@ public class AdRequestFactory {
 
         adRequest.locale = mDeviceInfo.getLocale().getLanguage();
 
-        if (!HyBid.isCoppaEnabled() && !limitTracking && !isCCPAOptOut) {
+        if (!HyBid.isCoppaEnabled() && !limitTracking && !isCCPAOptOut && !mUserDataManager.isConsentDenied()) {
             adRequest.age = HyBid.getAge();
             adRequest.gender = HyBid.getGender();
             adRequest.keywords = HyBid.getKeywords();
@@ -157,7 +157,7 @@ public class AdRequestFactory {
 
         if (mLocationManager != null) {
             Location location = mLocationManager.getUserLocation();
-            if (location != null && !HyBid.isCoppaEnabled() && !limitTracking) {
+            if (location != null && !HyBid.isCoppaEnabled() && !limitTracking && !mUserDataManager.isConsentDenied()) {
                 adRequest.latitude = String.format(Locale.ENGLISH, "%.6f", location.getLatitude());
                 adRequest.longitude = String.format(Locale.ENGLISH, "%.6f", location.getLongitude());
             }


### PR DESCRIPTION
This PR contains the following changes:
- Create a method on user data manager to check if consent has been explicitly denied
- Remove user info params from ad request if the consent is explicitly denied.